### PR TITLE
Add XML definition of D-Bus objects

### DIFF
--- a/dbus/org-opensuse-DInstaller-Language1.xml
+++ b/dbus/org-opensuse-DInstaller-Language1.xml
@@ -1,0 +1,39 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Language1">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Language1">
+    <method name="ToInstall">
+      <arg name="LangIDs" direction="in" type="as"/>
+    </method>
+    <method name="Finish">
+    </method>
+    <property type="a(ssa{sv})" name="AvailableLanguages" access="read"/>
+    <property type="as" name="MarkedForInstall" access="read"/>
+  </interface>
+</node>

--- a/dbus/org-opensuse-DInstaller-Manager1.xml
+++ b/dbus/org-opensuse-DInstaller-Manager1.xml
@@ -1,0 +1,55 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Manager1">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Progress1">
+    <property type="u" name="TotalSteps" access="read"/>
+    <property type="(us)" name="CurrentStep" access="read"/>
+    <property type="b" name="Finished" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.ServiceStatus1">
+    <property type="aa{sv}" name="All" access="read"/>
+    <property type="u" name="Current" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Manager1">
+    <method name="Probe">
+    </method>
+    <method name="Commit">
+    </method>
+    <method name="CanInstall">
+      <arg name="result" direction="out" type="b"/>
+    </method>
+    <method name="CollectLogs">
+      <arg name="user" direction="in" type="s"/>
+      <arg name="tarball_filesystem_path" direction="out" type="s"/>
+    </method>
+    <property type="aa{sv}" name="InstallationPhases" access="read"/>
+    <property type="u" name="CurrentInstallationPhase" access="read"/>
+    <property type="as" name="BusyServices" access="read"/>
+  </interface>
+</node>

--- a/dbus/org-opensuse-DInstaller-Questions1.xml
+++ b/dbus/org-opensuse-DInstaller-Questions1.xml
@@ -1,0 +1,61 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Questions1">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.ObjectManager">
+    <method name="GetManagedObjects">
+      <arg name="res" direction="out" type="a{oa{sa{sv}}}"/>
+    </method>
+    <signal name="InterfacesAdded">
+      <arg name="object" type="o"/>
+      <arg name="interfaces_and_properties" type="a{sa{sv}}"/>
+    </signal>
+    <signal name="InterfacesRemoved">
+      <arg name="object" type="o"/>
+      <arg name="interfaces" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Questions1">
+    <method name="New">
+      <arg name="text" direction="in" type="s"/>
+      <arg name="options" direction="in" type="as"/>
+      <arg name="default_option" direction="in" type="as"/>
+      <arg name="q" direction="out" type="o"/>
+    </method>
+    <method name="NewLuksActivation">
+      <arg name="device" direction="in" type="s"/>
+      <arg name="label" direction="in" type="s"/>
+      <arg name="size" direction="in" type="s"/>
+      <arg name="attempt" direction="in" type="y"/>
+      <arg name="q" direction="out" type="o"/>
+    </method>
+    <method name="Delete">
+      <arg name="question" direction="in" type="o"/>
+    </method>
+  </interface>
+</node>

--- a/dbus/org-opensuse-DInstaller-Software-Proposal1.xml
+++ b/dbus/org-opensuse-DInstaller-Software-Proposal1.xml
@@ -1,0 +1,56 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Software/Proposal1">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Software.Proposal1">
+    <method name="AddResolvables">
+      <arg name="Id" direction="in" type="s"/>
+      <arg name="Type" direction="in" type="y"/>
+      <arg name="Resolvables" direction="in" type="as"/>
+      <arg name="Optional" direction="in" type="b"/>
+    </method>
+    <method name="GetResolvables">
+      <arg name="Id" direction="in" type="s"/>
+      <arg name="Type" direction="in" type="y"/>
+      <arg name="Optional" direction="in" type="b"/>
+      <arg name="Resolvables" direction="out" type="as"/>
+    </method>
+    <method name="SetResolvables">
+      <arg name="Id" direction="in" type="s"/>
+      <arg name="Type" direction="in" type="y"/>
+      <arg name="Resolvables" direction="in" type="as"/>
+      <arg name="Optional" direction="in" type="b"/>
+    </method>
+    <method name="RemoveResolvables">
+      <arg name="Id" direction="in" type="s"/>
+      <arg name="Type" direction="in" type="y"/>
+      <arg name="Resolvables" direction="in" type="as"/>
+      <arg name="Optional" direction="in" type="b"/>
+    </method>
+  </interface>
+</node>

--- a/dbus/org-opensuse-DInstaller-Software1.xml
+++ b/dbus/org-opensuse-DInstaller-Software1.xml
@@ -1,0 +1,73 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Software1">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Progress1">
+    <property type="u" name="TotalSteps" access="read"/>
+    <property type="(us)" name="CurrentStep" access="read"/>
+    <property type="b" name="Finished" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.ServiceStatus1">
+    <property type="aa{sv}" name="All" access="read"/>
+    <property type="u" name="Current" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Validation1">
+    <property type="as" name="Errors" access="read"/>
+    <property type="b" name="Valid" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Software1">
+    <method name="SelectProduct">
+      <arg name="ProductID" direction="in" type="s"/>
+    </method>
+    <method name="ProvisionSelected">
+      <arg name="Provision" direction="in" type="s"/>
+      <arg name="Result" direction="out" type="b"/>
+    </method>
+    <method name="ProvisionsSelected">
+      <arg name="Provisions" direction="in" type="as"/>
+      <arg name="Result" direction="out" type="ab"/>
+    </method>
+    <method name="IsPackageInstalled">
+      <arg name="Name" direction="in" type="s"/>
+      <arg name="Result" direction="out" type="b"/>
+    </method>
+    <method name="UsedDiskSpace">
+      <arg name="SpaceSize" direction="out" type="s"/>
+    </method>
+    <method name="Probe">
+    </method>
+    <method name="Propose">
+    </method>
+    <method name="Install">
+    </method>
+    <method name="Finish">
+    </method>
+    <property type="a(ssa{sv})" name="AvailableBaseProducts" access="read"/>
+    <property type="s" name="SelectedBaseProduct" access="read"/>
+  </interface>
+</node>

--- a/dbus/org-opensuse-DInstaller-Storage1-Proposal.xml
+++ b/dbus/org-opensuse-DInstaller-Storage1-Proposal.xml
@@ -1,0 +1,37 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Storage1/Proposal">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Storage1.Proposal">
+    <property type="as" name="CandidateDevices" access="read"/>
+    <property type="b" name="LVM" access="read"/>
+    <property type="s" name="EncryptionPassword" access="read"/>
+    <property type="aa{sv}" name="Volumes" access="read"/>
+    <property type="aa{sv}" name="Actions" access="read"/>
+  </interface>
+</node>

--- a/dbus/org-opensuse-DInstaller-Storage1.xml
+++ b/dbus/org-opensuse-DInstaller-Storage1.xml
@@ -1,0 +1,74 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Storage1">
+  <node name="Proposal" />
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.freedesktop.DBus.ObjectManager">
+    <method name="GetManagedObjects">
+      <arg name="res" direction="out" type="a{oa{sa{sv}}}"/>
+    </method>
+    <signal name="InterfacesAdded">
+      <arg name="object" type="o"/>
+      <arg name="interfaces_and_properties" type="a{sa{sv}}"/>
+    </signal>
+    <signal name="InterfacesRemoved">
+      <arg name="object" type="o"/>
+      <arg name="interfaces" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Progress1">
+    <property type="u" name="TotalSteps" access="read"/>
+    <property type="(us)" name="CurrentStep" access="read"/>
+    <property type="b" name="Finished" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.ServiceStatus1">
+    <property type="aa{sv}" name="All" access="read"/>
+    <property type="u" name="Current" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Validation1">
+    <property type="as" name="Errors" access="read"/>
+    <property type="b" name="Valid" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Storage1">
+    <method name="Probe">
+    </method>
+    <method name="Install">
+    </method>
+    <method name="Finish">
+    </method>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Storage1.Proposal.Calculator">
+    <method name="Calculate">
+      <arg name="settings" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <property type="a(ssa{sv})" name="AvailableDevices" access="read"/>
+    <property type="aa{sv}" name="VolumeTemplates" access="read"/>
+    <property type="o" name="Result" access="read"/>
+  </interface>
+</node>

--- a/dbus/org-opensuse-DInstaller-Users1.xml
+++ b/dbus/org-opensuse-DInstaller-Users1.xml
@@ -1,0 +1,69 @@
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node name="/org/opensuse/DInstaller/Users1">
+  <interface name="org.freedesktop.DBus.Properties">
+    <method name="Get">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="v"/>
+    </method>
+    <method name="Set">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="property_name" direction="in" type="s"/>
+      <arg name="val" direction="in" type="v"/>
+    </method>
+    <method name="GetAll">
+      <arg name="interface_name" direction="in" type="s"/>
+      <arg name="value" direction="out" type="a{sv}"/>
+    </method>
+    <signal name="PropertiesChanged">
+      <arg name="interface" type="s"/>
+      <arg name="changed_properties" type="a{sv}"/>
+      <arg name="invalidated_properties" type="as"/>
+    </signal>
+  </interface>
+  <interface name="org.freedesktop.DBus.Introspectable">
+    <method name="Introspect">
+      <arg name="xml_data" direction="out" type="s"/>
+    </method>
+  </interface>
+  <interface name="org.opensuse.DInstaller.ServiceStatus1">
+    <property type="aa{sv}" name="All" access="read"/>
+    <property type="u" name="Current" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Validation1">
+    <property type="as" name="Errors" access="read"/>
+    <property type="b" name="Valid" access="read"/>
+  </interface>
+  <interface name="org.opensuse.DInstaller.Users1">
+    <method name="SetRootPassword">
+      <arg name="Value" direction="in" type="s"/>
+      <arg name="Encrypted" direction="in" type="b"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="RemoveRootPassword">
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="SetRootSSHKey">
+      <arg name="Value" direction="in" type="s"/>
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="SetFirstUser">
+      <arg name="FullName" direction="in" type="s"/>
+      <arg name="UserName" direction="in" type="s"/>
+      <arg name="Password" direction="in" type="s"/>
+      <arg name="AutoLogin" direction="in" type="b"/>
+      <arg name="data" direction="in" type="a{sv}"/>
+      <arg name="result" direction="out" type="(bas)"/>
+    </method>
+    <method name="RemoveFirstUser">
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <method name="Write">
+      <arg name="result" direction="out" type="u"/>
+    </method>
+    <property type="b" name="RootPasswordSet" access="read"/>
+    <property type="s" name="RootSSHKey" access="read"/>
+    <property type="(ssba{sv})" name="FirstUser" access="read"/>
+  </interface>
+</node>


### PR DESCRIPTION
Just in case they are useful (for instance, to feed `zbus_xmlgen`).

```
busctl --address unix:path=/run/d-installer/bus introspect \
  org.opensuse.DInstaller /org/opensuse/DInstaller/Manager1
```