### PR TITLE
add initial users client

### DIFF
--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -26,7 +26,7 @@ fn info(keys: Vec<String>, format: Option<Format>) -> Result<(), Box<dyn error::
 
     let stdout = std::io::stdout();
     match key.as_str() {
-        "users" => print(users::users(), stdout, format),
+        "users" => print(users::first_user()?, stdout, format),
         "storage.candidate_devices" => print(storage::candidate_devices()?, stdout, format),
         "storage.available_devices" => print(storage::available_devices()?, stdout, format),
         "products" => print(software::products(), stdout, format),

--- a/dinstaller-lib/src/proxies.rs
+++ b/dinstaller-lib/src/proxies.rs
@@ -333,7 +333,9 @@ trait StorageProposal {
 #[dbus_proxy(
     interface = "org.opensuse.DInstaller.Users1",
     default_service = "org.opensuse.DInstaller.Users",
-    default_path = "/org/opensuse/DInstaller/Users1"
+    default_path = "/org/opensuse/DInstaller/Users1",
+    gen_async = false,
+    gen_blocking = true
 )]
 trait Users1 {
     /// RemoveFirstUser method

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -1,14 +1,70 @@
+use super::proxies::Users1Proxy;
+use zbus::blocking::Connection;
 use serde::Serialize;
 
-#[derive(Debug, Serialize)]
-pub struct User {
-    pub login: String
+pub struct UsersClient<'a> {
+    users_proxy: Users1Proxy<'a>,
 }
 
-pub fn users() -> Vec<User> {
-    vec![
-        User { login: "foobar".to_string() },
-        User { login: "jonh.doe".to_string() },
-        User { login: "jane.doe".to_string() }
-    ]
+#[derive(Serialize, Debug)]
+pub struct FirstUser {
+    pub full_name: String,
+    pub user_name: String,
+    pub autologin: bool,
+    pub data: std::collections::HashMap<String, zbus::zvariant::OwnedValue>
+}
+
+impl FirstUser {
+    fn from_dbus(dbus_data: zbus::Result<(
+        String,
+        String,
+        bool,
+        std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
+    )>) -> zbus::Result<Self> {
+        let data = dbus_data?;
+        Ok(
+            Self { 
+                full_name: data.0,
+                user_name: data.1,
+                autologin: data.2,
+                data: data.3
+            }
+        )
+    }
+}
+
+impl<'a> UsersClient<'a> {
+    pub fn new(connection: Connection) -> zbus::Result<Self> {
+        Ok(Self { 
+            users_proxy: Users1Proxy::new(&connection)?
+        })
+    }
+
+    /// Returns the settings for first non admin user
+    pub fn first_user(&self) -> zbus::Result<FirstUser> {
+        FirstUser::from_dbus(self.users_proxy.first_user())
+    }
+
+    pub fn is_root_password(&self) -> zbus::Result<bool> {
+        self.users_proxy.root_password_set()
+    }
+
+    pub fn root_ssh_key(&self) -> zbus::Result<String> {
+        self.users_proxy.root_sshkey()
+    }
+}
+
+pub fn first_user() -> zbus::Result<FirstUser> {
+    let client = UsersClient::new(super::connection()?)?;
+    client.first_user()
+}
+
+pub fn is_root_password() -> zbus::Result<bool> {
+    let client = UsersClient::new(super::connection()?)?;
+    client.is_root_password()
+}
+
+pub fn root_ssh_key() -> zbus::Result<String> {
+    let client = UsersClient::new(super::connection()?)?;
+    client.root_ssh_key()
 }


### PR DESCRIPTION
I add initial client for users that can now just read. There is a few changes to your code:

1. I use super::connection instead of ConnectionBuilder with own address
2. I do not store connection in client
3. I am still not sure why specific lifetime is needed for that Proxy.