### PR TITLE
feat: implement the "config set" command

### DIFF
--- a/dinstaller-cli/src/commands.rs
+++ b/dinstaller-cli/src/commands.rs
@@ -1,18 +1,5 @@
 use clap::Subcommand;
-
-#[derive(Subcommand, Debug)]
-pub enum ConfigCommands {
-    /// Set one or many installation settings
-    Set {
-        /// key-value pairs (e.g., user.name="Jane Doe")
-        values: Vec<String>,
-    },
-    /// Shows the value of one or many configuration settings
-    Show {
-        /// Keys to show
-        keys: Vec<String>,
-    },
-}
+use crate::config::ConfigCommands;
 
 #[derive(Subcommand, Debug)]
 pub enum Commands {

--- a/dinstaller-cli/src/config.rs
+++ b/dinstaller-cli/src/config.rs
@@ -43,10 +43,12 @@ fn parse_config_command(subcommand: ConfigCommands) -> ConfigAction {
             ConfigAction::Show(keys)
         },
         ConfigCommands::Set { values } => {
-            let changes: HashMap<String, String> = values.iter().map(|s| {
-                let (key, value) = s.split_once("=").unwrap();
-                // let key = SettingsKey::from_str(key).unwrap();
-                (key.to_string(), value.to_string())
+            let changes: HashMap<String, String> = values.iter().filter_map(|s| {
+                if let Some((key, value)) = s.split_once("=") {
+                    Some((key.to_string(), value.to_string()))
+                } else {
+                    None
+                }
             }).collect();
             ConfigAction::Set(changes)
         }

--- a/dinstaller-cli/src/config.rs
+++ b/dinstaller-cli/src/config.rs
@@ -1,0 +1,59 @@
+use clap::Subcommand;
+use std::{collections::HashMap, error::Error, str::FromStr};
+use dinstaller_lib::settings::{
+    ItemsRepository, Key as SettingsKey, Store as SettingsStore
+};
+
+#[derive(Subcommand, Debug)]
+pub enum ConfigCommands {
+    /// Set one or many installation settings
+    Set {
+        /// key-value pairs (e.g., user.name="Jane Doe")
+        values: Vec<String>,
+    },
+    /// Shows the value of one or many configuration settings
+    Show {
+        /// Keys to show
+        keys: Vec<String>,
+    },
+}
+
+pub enum ConfigAction {
+    Set(HashMap<SettingsKey, String>),
+    Show(Vec<SettingsKey>)
+}
+
+pub fn run(subcommand: ConfigCommands) -> Result<(), Box<dyn Error>> {
+    match parse_config_command(subcommand) {
+        ConfigAction::Set(changes) => {
+            let store = SettingsStore::new()?;
+            let mut model = store.load()?;
+            let settings_items = ItemsRepository::default_repository()?;
+
+            for (key, value) in &changes {
+                if let Some(item) = settings_items.find_by_key(key) {
+                    (item.update_handler)(&mut model, value)
+                }
+            }
+            store.store(&model)
+        },
+        _ => unimplemented!()
+    }
+}
+
+fn parse_config_command(subcommand: ConfigCommands) -> ConfigAction {
+    match subcommand {
+        ConfigCommands::Show { keys } => {
+            let keys = keys.iter().filter_map(|k| SettingsKey::from_str(&k).ok()).collect();
+            ConfigAction::Show(keys)
+        },
+        ConfigCommands::Set { values } => {
+            let changes: HashMap<SettingsKey, String> = values.iter().map(|s| {
+                let (key, value) = s.split_once("=").unwrap();
+                let key = SettingsKey::from_str(key).unwrap();
+                (key, value.to_string())
+            }).collect();
+            ConfigAction::Set(changes)
+        }
+    }
+}

--- a/dinstaller-cli/src/lib.rs
+++ b/dinstaller-cli/src/lib.rs
@@ -1,2 +1,0 @@
-pub mod printers;
-pub mod commands;

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -1,9 +1,14 @@
 use clap::Parser;
 use std::error;
 
-use dinstaller_cli::commands::{Commands, ConfigCommands};
+mod commands;
+mod config;
+mod printers;
+
+use commands::Commands;
+use config::run as run_config_cmd;
 use dinstaller_lib::{software, storage, users};
-use dinstaller_cli::printers::{print, Format};
+use printers::{print, Format};
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -1,5 +1,4 @@
 use clap::Parser;
-use std::error;
 
 mod commands;
 mod config;
@@ -7,8 +6,7 @@ mod printers;
 
 use commands::Commands;
 use config::run as run_config_cmd;
-use dinstaller_lib::{software, storage, users};
-use printers::{print, Format};
+use printers::Format;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -21,31 +19,10 @@ struct Cli {
     pub format: Option<Format>
 }
 
-/// Displays information about a given configuration parameter
-///
-/// This function does not handle the `keys` argument properly yet.
-fn info(keys: Vec<String>, format: Option<Format>) -> Result<(), Box<dyn error::Error>> {
-    let products = "products".to_string();
-    let key = keys.get(0)
-        .unwrap_or(&products);
-
-    let stdout = std::io::stdout();
-    match key.as_str() {
-        "users" => print(users::first_user()?, stdout, format),
-        "storage.candidate_devices" => print(storage::candidate_devices()?, stdout, format),
-        "storage.available_devices" => print(storage::available_devices()?, stdout, format),
-        "products" => print(software::products(), stdout, format),
-        _ => {
-            println!("unknown key");
-            Ok(())
-        }
-    }
-}
-
 fn main() {
     let cli = Cli::parse();
     match cli.command {
-        Commands::Info { keys } => info(keys, cli.format).unwrap(),
-        Commands::Config(subcommand) => run_config_cmd(subcommand).unwrap()
+        Commands::Config(subcommand) => run_config_cmd(subcommand).unwrap(),
+        _ => unimplemented!()
     }
 }

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -42,21 +42,10 @@ fn info(keys: Vec<String>, format: Option<Format>) -> Result<(), Box<dyn error::
     }
 }
 
-fn show_config(keys: Vec<String>) {
-    unimplemented!("Show config for {:?}", &keys);
-}
-
-fn set_config(values: Vec<String>) {
-    unimplemented!("Set config values {:?}", &values);
-}
-
 fn main() {
     let cli = Cli::parse();
     match cli.command {
         Commands::Info { keys } => info(keys, cli.format).unwrap(),
-        Commands::Config(subcommand) => match subcommand {
-            ConfigCommands::Show { keys } => show_config(keys),
-            ConfigCommands::Set { values } => set_config(values),
-        },
+        Commands::Config(subcommand) => run_config_cmd(subcommand).unwrap()
     }
 }

--- a/dinstaller-lib/src/attributes.rs
+++ b/dinstaller-lib/src/attributes.rs
@@ -1,0 +1,50 @@
+use std::convert::TryFrom;
+
+pub struct AttributeValue(String);
+
+pub trait Attributes {
+    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str>;
+}
+
+impl TryFrom<AttributeValue> for bool {
+    type Error = &'static str;
+
+    fn try_from(value: AttributeValue) -> Result<Self, Self::Error> {
+        match value.0.as_str() {
+            "true" | "yes" | "t" => Ok(true),
+            "false" | "no" | "f" => Ok(false),
+            _ => Err("not a valid boolean")
+        }
+    }
+}
+
+impl TryFrom<AttributeValue> for String {
+    type Error = &'static str;
+
+    fn try_from(value: AttributeValue) -> Result<Self, Self::Error> {
+        Ok(value.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_from_bool() {
+        let value = AttributeValue("true".to_string());
+        let value: bool = value.try_into().unwrap();
+        assert_eq!(value, true);
+
+        let value = AttributeValue("false".to_string());
+        let value: bool = value.try_into().unwrap();
+        assert_eq!(value, false);
+    }
+
+    #[test]
+    fn test_try_from_string() {
+        let value = AttributeValue("some value".to_string());
+        let value: String = value.try_into().unwrap();
+        assert_eq!(value, "some value");
+    }
+}

--- a/dinstaller-lib/src/attributes.rs
+++ b/dinstaller-lib/src/attributes.rs
@@ -10,7 +10,7 @@ impl TryFrom<AttributeValue> for bool {
     type Error = &'static str;
 
     fn try_from(value: AttributeValue) -> Result<Self, Self::Error> {
-        match value.0.as_str() {
+        match value.0.to_lowercase().as_str() {
             "true" | "yes" | "t" => Ok(true),
             "false" | "no" | "f" => Ok(false),
             _ => Err("not a valid boolean")

--- a/dinstaller-lib/src/attributes.rs
+++ b/dinstaller-lib/src/attributes.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-pub struct AttributeValue(String);
+pub struct AttributeValue(pub String);
 
 pub trait Attributes {
     fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str>;

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod attributes;
 pub mod software;
 pub mod storage;
 pub mod users;

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -3,6 +3,7 @@ pub mod storage;
 pub mod users;
 // TODO: maybe expose only clients when we have it?
 pub mod proxies;
+pub mod settings;
 
 use std::path::Path;
 

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -1,6 +1,6 @@
-use crate::users::{UsersClient,FirstUser};
+use crate::users::{UsersClient, FirstUser};
 use crate::storage::StorageClient;
-use std::{str::FromStr, error::Error};
+use std::{str::FromStr, error::Error, default::Default};
 use crate::attributes::{Attributes, AttributeValue};
 
 #[derive(Debug, Default)]
@@ -64,7 +64,6 @@ impl Attributes for StorageSettings {
 ///
 /// It is responsible for loading and storing the settings in the D-Bus service.
 pub struct Store<'a> {
-    storage_client: StorageClient<'a>,
     users_client: UsersClient<'a>,
 }
 
@@ -72,7 +71,6 @@ impl<'a> Store<'a> {
     pub fn new() -> Result<Self, Box<dyn Error>> {
         Ok(
             Self {
-                storage_client: StorageClient::new(super::connection()?)?,
                 users_client: UsersClient::new(super::connection()?)?
             }
         )
@@ -80,39 +78,30 @@ impl<'a> Store<'a> {
 
     /// Loads the installation settings from the D-Bus service
     pub fn load(&self) -> Result<Settings, Box<dyn Error>> {
-        let mut settings = Settings::default();
-        settings.users = Some(UsersSettings {
-            first_user: Some(self.users_client.first_user()?)
-        });
+        let first_user = self.users_client.first_user()?;
+        let settings = Settings {
+            users: UsersSettings {
+                user_name: first_user.user_name,
+                autologin: first_user.autologin,
+                full_name: first_user.full_name,
+                password:  first_user.password
+            }
+        };
         Ok(settings)
     }
 
     /// Stores the given installation settings in the D-Bus service
     pub fn store(&self, settings: &Settings) -> Result<(), Box<dyn Error>> {
         dbg!("Storing the following settings", settings);
-        if let Some(users_settings) = &settings.users {
-            if let Some(first_user) = &users_settings.first_user {
-                self.users_client.set_first_user(&first_user)?;
-            }
-        }
+        let first_user = FirstUser {
+            user_name: settings.users.user_name.clone(),
+            full_name: settings.users.full_name.clone(),
+            autologin: settings.users.autologin.clone(),
+            password: settings.users.password.clone(),
+            ..Default::default()
+        };
+        self.users_client.set_first_user(&first_user)?;
         Ok(())
-    }
-}
-
-type UpdateFn = fn(&mut Settings, value: &str);
-
-/// Represents a configuration item that can be handled by the CLI
-///
-/// It contains a key, a description and a function to update the settings model.
-pub struct Item {
-    pub key: Key,
-    pub description: String,
-    pub update_handler: UpdateFn
-}
-
-impl Item {
-    pub fn new(key: Key, description: String, update_handler: UpdateFn) -> Self {
-        Self { key, description, update_handler }
     }
 }
 
@@ -128,56 +117,5 @@ impl FromStr for Key {
             return Ok(Self(ns.to_string(), id.to_string()))
         }
         Err(format!("not a valid configuration key: {}", s).to_string())
-    }
-}
-
-/// Repository containing the known configuration items
-///
-/// It offers a mechanism to store and search for a given configuration item using its key.
-pub struct ItemsRepository {
-    config_items: Vec<Item>
-}
-
-impl ItemsRepository {
-    pub fn new() -> Self {
-        Self { config_items: vec![] }
-    }
-
-    pub fn add(&mut self, config_item: Item) {
-        self.config_items.push(config_item)
-    }
-
-    pub fn find_by_key(&self, key: &Key) -> Option<&Item> {
-        self.config_items.iter().find(|c| &c.key == key)
-    }
-
-    pub fn default_repository() -> Result<Self, Box<dyn Error>> {
-        let mut repository = ItemsRepository::new();
-        repository.add(
-            Item::new("users.full_name".parse()?, "First user full name".to_string(), |s, value| {
-                // FIXME: We can simplify this code quite a lot by extending the Settings class.
-                if let Some(users) = &mut s.users {
-                    if let Some(first_user) = &mut users.first_user {
-                        first_user.full_name = value.to_string()
-                    }
-                }
-            })
-        );
-        repository.add(
-            Item::new("users.username".parse()?, "First user login".to_string(), |s, value| {
-                // FIXME: We can simplify this code quite a lot by extending the Settings class.
-                if let Some(users) = &mut s.users {
-                    if let Some(first_user) = &mut users.first_user {
-                        first_user.user_name = value.to_string()
-                    }
-                }
-            })
-        );
-        repository.add(
-            Item::new("storage.lvm".parse()?, "Whether to enable LVM".to_string(), |_s, value| {
-                println!("Setting LVM to {}", value);
-            })
-        );
-        Ok(repository)
     }
 }

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -4,17 +4,22 @@ use std::{str::FromStr, error::Error};
 
 #[derive(Debug, Default)]
 pub struct Settings {
-    pub users: Option<UsersSettings>,
-    pub storage: Option<StorageSettings>
+    pub users: UsersSettings,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct UsersSettings {
-    pub first_user: Option<FirstUser>
+    pub full_name: String,
+    pub user_name: String,
+    pub password: String,
+    pub autologin: bool,
 }
 
 #[derive(Debug)]
 pub struct StorageSettings {
+    lvm: bool,
+    encryption_password: String
+}
 
 }
 

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -47,6 +47,7 @@ impl<'a> Store<'a> {
 
     /// Stores the given installation settings in the D-Bus service
     pub fn store(&self, settings: &Settings) -> Result<(), Box<dyn Error>> {
+        dbg!("Storing the following settings", settings);
         if let Some(users_settings) = &settings.users {
             if let Some(first_user) = &users_settings.first_user {
                 self.users_client.set_first_user(&first_user)?;
@@ -116,6 +117,16 @@ impl ItemsRepository {
                 if let Some(users) = &mut s.users {
                     if let Some(first_user) = &mut users.first_user {
                         first_user.full_name = value.to_string()
+                    }
+                }
+            })
+        );
+        repository.add(
+            Item::new("users.username".parse()?, "First user login".to_string(), |s, value| {
+                // FIXME: We can simplify this code quite a lot by extending the Settings class.
+                if let Some(users) = &mut s.users {
+                    if let Some(first_user) = &mut users.first_user {
+                        first_user.user_name = value.to_string()
                     }
                 }
             })

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -1,6 +1,7 @@
 use crate::users::{UsersClient,FirstUser};
 use crate::storage::StorageClient;
 use std::{str::FromStr, error::Error};
+use crate::attributes::{Attributes, AttributeValue};
 
 #[derive(Debug, Default)]
 pub struct Settings {
@@ -21,6 +22,42 @@ pub struct StorageSettings {
     encryption_password: String
 }
 
+impl Attributes for Settings {
+    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+        if let Some((ns, id)) = attr.split_once(".") {
+            match ns {
+                "users" => {
+                    self.users.set_attribute(id, value)?
+                },
+                _ => return Err("unknown attribute")
+            }
+        }
+        Ok(())
+    }
+}
+
+impl Attributes for UsersSettings {
+    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+        match attr {
+            "full_name" => self.full_name = value.try_into()?,
+            "user_name" => self.user_name = value.try_into()?,
+            "password" => self.password = value.try_into()?,
+            "autologin" => self.autologin = value.try_into()?,
+            _ => return Err("unknown attribute")
+        }
+        Ok(())
+    }
+}
+
+impl Attributes for StorageSettings {
+    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+        match attr {
+            "lvm" => self.lvm = value.try_into()?,
+            "encryption_password" => self.encryption_password = value.try_into()?,
+            _ => return Err("unknown attribute")
+        }
+        Ok(())
+    }
 }
 
 /// Settings storage

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -1,0 +1,130 @@
+use crate::users::{UsersClient,FirstUser};
+use crate::storage::StorageClient;
+use std::{str::FromStr, error::Error};
+
+#[derive(Debug, Default)]
+pub struct Settings {
+    pub users: Option<UsersSettings>,
+    pub storage: Option<StorageSettings>
+}
+
+#[derive(Debug)]
+pub struct UsersSettings {
+    pub first_user: Option<FirstUser>
+}
+
+#[derive(Debug)]
+pub struct StorageSettings {
+
+}
+
+/// Settings storage
+///
+/// It is responsible for loading and storing the settings in the D-Bus service.
+pub struct Store<'a> {
+    storage_client: StorageClient<'a>,
+    users_client: UsersClient<'a>,
+}
+
+impl<'a> Store<'a> {
+    pub fn new() -> Result<Self, Box<dyn Error>> {
+        Ok(
+            Self {
+                storage_client: StorageClient::new(super::connection()?)?,
+                users_client: UsersClient::new(super::connection()?)?
+            }
+        )
+    }
+
+    /// Loads the installation settings from the D-Bus service
+    pub fn load(&self) -> Result<Settings, Box<dyn Error>> {
+        let mut settings = Settings::default();
+        settings.users = Some(UsersSettings {
+            first_user: Some(self.users_client.first_user()?)
+        });
+        Ok(settings)
+    }
+
+    /// Stores the given installation settings in the D-Bus service
+    pub fn store(&self, settings: &Settings) -> Result<(), Box<dyn Error>> {
+        if let Some(users_settings) = &settings.users {
+            if let Some(first_user) = &users_settings.first_user {
+                self.users_client.set_first_user(&first_user)?;
+            }
+        }
+        Ok(())
+    }
+}
+
+type UpdateFn = fn(&mut Settings, value: &str);
+
+/// Represents a configuration item that can be handled by the CLI
+///
+/// It contains a key, a description and a function to update the settings model.
+pub struct Item {
+    pub key: Key,
+    pub description: String,
+    pub update_handler: UpdateFn
+}
+
+impl Item {
+    pub fn new(key: Key, description: String, update_handler: UpdateFn) -> Self {
+        Self { key, description, update_handler }
+    }
+}
+
+/// Represents a key (the name) of a settings item
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct Key(pub String, pub String);
+
+impl FromStr for Key {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some((ns, id)) = s.split_once(".") {
+            return Ok(Self(ns.to_string(), id.to_string()))
+        }
+        Err(format!("not a valid configuration key: {}", s).to_string())
+    }
+}
+
+/// Repository containing the known configuration items
+///
+/// It offers a mechanism to store and search for a given configuration item using its key.
+pub struct ItemsRepository {
+    config_items: Vec<Item>
+}
+
+impl ItemsRepository {
+    pub fn new() -> Self {
+        Self { config_items: vec![] }
+    }
+
+    pub fn add(&mut self, config_item: Item) {
+        self.config_items.push(config_item)
+    }
+
+    pub fn find_by_key(&self, key: &Key) -> Option<&Item> {
+        self.config_items.iter().find(|c| &c.key == key)
+    }
+
+    pub fn default_repository() -> Result<Self, Box<dyn Error>> {
+        let mut repository = ItemsRepository::new();
+        repository.add(
+            Item::new("users.full_name".parse()?, "First user full name".to_string(), |s, value| {
+                // FIXME: We can simplify this code quite a lot by extending the Settings class.
+                if let Some(users) = &mut s.users {
+                    if let Some(first_user) = &mut users.first_user {
+                        first_user.full_name = value.to_string()
+                    }
+                }
+            })
+        );
+        repository.add(
+            Item::new("storage.lvm".parse()?, "Whether to enable LVM".to_string(), |_s, value| {
+                println!("Setting LVM to {}", value);
+            })
+        );
+        Ok(repository)
+    }
+}

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -68,7 +68,7 @@ pub struct Store<'a> {
 }
 
 impl<'a> Store<'a> {
-    pub fn new() -> Result<Self, Box<dyn Error>> {
+    pub fn new() -> Result<Self, zbus::Error> {
         Ok(
             Self {
                 users_client: UsersClient::new(super::connection()?)?

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -5,11 +5,11 @@ use crate::attributes::{Attributes, AttributeValue};
 
 #[derive(Debug, Default)]
 pub struct Settings {
-    pub users: UsersSettings,
+    pub user: UserSettings,
 }
 
 #[derive(Debug, Default)]
-pub struct UsersSettings {
+pub struct UserSettings {
     pub full_name: String,
     pub user_name: String,
     pub password: String,
@@ -27,7 +27,7 @@ impl Attributes for Settings {
         if let Some((ns, id)) = attr.split_once(".") {
             match ns {
                 "users" => {
-                    self.users.set_attribute(id, value)?
+                    self.user.set_attribute(id, value)?
                 },
                 _ => return Err("unknown attribute")
             }
@@ -36,7 +36,7 @@ impl Attributes for Settings {
     }
 }
 
-impl Attributes for UsersSettings {
+impl Attributes for UserSettings {
     fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
         match attr {
             "full_name" => self.full_name = value.try_into()?,
@@ -80,7 +80,7 @@ impl<'a> Store<'a> {
     pub fn load(&self) -> Result<Settings, Box<dyn Error>> {
         let first_user = self.users_client.first_user()?;
         let settings = Settings {
-            users: UsersSettings {
+            user: UserSettings {
                 user_name: first_user.user_name,
                 autologin: first_user.autologin,
                 full_name: first_user.full_name,
@@ -93,11 +93,12 @@ impl<'a> Store<'a> {
     /// Stores the given installation settings in the D-Bus service
     pub fn store(&self, settings: &Settings) -> Result<(), Box<dyn Error>> {
         dbg!("Storing the following settings", settings);
+        // fixme: improve
         let first_user = FirstUser {
-            user_name: settings.users.user_name.clone(),
-            full_name: settings.users.full_name.clone(),
-            autologin: settings.users.autologin.clone(),
-            password: settings.users.password.clone(),
+            user_name: settings.user.user_name.clone(),
+            full_name: settings.user.full_name.clone(),
+            autologin: settings.user.autologin.clone(),
+            password: settings.user.password.clone(),
             ..Default::default()
         };
         self.users_client.set_first_user(&first_user)?;

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -26,7 +26,7 @@ impl Attributes for Settings {
     fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
         if let Some((ns, id)) = attr.split_once(".") {
             match ns {
-                "users" => {
+                "user" => {
                     self.user.set_attribute(id, value)?
                 },
                 _ => return Err("unknown attribute")

--- a/dinstaller-lib/src/storage.rs
+++ b/dinstaller-lib/src/storage.rs
@@ -47,20 +47,6 @@ impl<'a> StorageClient<'a> {
     }
 }
 
-pub fn available_devices() -> zbus::Result<Vec<StorageDevice>> {
-    let connection = ConnectionBuilder::address("unix:path=/run/d-installer/bus").unwrap()
-        .build().unwrap();
-    let client = StorageClient::new(connection)?;
-    client.available_devices()
-}
-
-pub fn candidate_devices() -> zbus::Result<Vec<String>> {
-    let connection = ConnectionBuilder::address("unix:path=/run/d-installer/bus").unwrap()
-        .build().unwrap();
-    let client = StorageClient::new(connection)?;
-    client.candidate_devices()
-}
-
 #[derive(Serialize, Debug)]
 pub struct StorageDevice {
     name: String,

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -1,12 +1,13 @@
 use super::proxies::Users1Proxy;
 use zbus::blocking::Connection;
 use serde::Serialize;
+use crate::attributes::{Attributes, AttributeValue};
 
 pub struct UsersClient<'a> {
     users_proxy: Users1Proxy<'a>,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Debug, Default)]
 pub struct FirstUser {
     pub full_name: String,
     pub user_name: String,
@@ -32,6 +33,19 @@ impl FirstUser {
                 password: "".to_string()
             }
         )
+    }
+}
+
+impl Attributes for FirstUser {
+    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+        match attr {
+            "full_name" => self.full_name = value.try_into()?,
+            "user_name" => self.user_name = value.try_into()?,
+            "password" => self.password = value.try_into()?,
+            "autologin" => self.autologin = value.try_into()?,
+            _ => return Err("unknown attribute")
+        }
+        Ok(())
     }
 }
 

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -65,18 +65,3 @@ impl<'a> UsersClient<'a> {
         )
     }
 }
-
-pub fn first_user() -> zbus::Result<FirstUser> {
-    let client = UsersClient::new(super::connection()?)?;
-    client.first_user()
-}
-
-pub fn is_root_password() -> zbus::Result<bool> {
-    let client = UsersClient::new(super::connection()?)?;
-    client.is_root_password()
-}
-
-pub fn root_ssh_key() -> zbus::Result<String> {
-    let client = UsersClient::new(super::connection()?)?;
-    client.root_ssh_key()
-}

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -10,6 +10,7 @@ pub struct UsersClient<'a> {
 pub struct FirstUser {
     pub full_name: String,
     pub user_name: String,
+    pub password: String,
     pub autologin: bool,
     pub data: std::collections::HashMap<String, zbus::zvariant::OwnedValue>
 }
@@ -27,7 +28,8 @@ impl FirstUser {
                 full_name: data.0,
                 user_name: data.1,
                 autologin: data.2,
-                data: data.3
+                data: data.3,
+                password: "".to_string()
             }
         )
     }
@@ -51,6 +53,16 @@ impl<'a> UsersClient<'a> {
 
     pub fn root_ssh_key(&self) -> zbus::Result<String> {
         self.users_proxy.root_sshkey()
+    }
+
+    pub fn set_first_user(&self, first_user: &FirstUser) -> zbus::Result<(bool, Vec<String>)> {
+        self.users_proxy.set_first_user(
+            &first_user.full_name,
+            &first_user.user_name,
+            &first_user.password,
+            first_user.autologin,
+            std::collections::HashMap::new()
+        )
     }
 }
 


### PR DESCRIPTION
## The problem

<details>
<summary>If you know what the problem is, feel free to skip to the next section. Otherwise, expand this section to know more.</summary>

Our team has defined a[ pretty nice CLI](https://gist.github.com/joseivanlopez/808c2be0cf668b4b457fc5d9ec20dc73) for D-Installer. As a user, you can modify several settings in one shot with something like:

```
$ dinstaller config set storage.lvm=false storage.encryption_password=1235 users.root_password=12345
$ dinstaller config add storage.candidate_devices /dev/sda
```

The problem is that the gap between our new CLI and the D-Bus API is rather big:

1. A corresponding key (e.g., storage.lvm) might not exist.
2. Usually, you cannot change a single value. For instance, if you want to change the storage settings, you need to calculate a new proposal by calling the `Calculate` method and passing many arguments.
3. You cannot ignore the current values. In many cases, you need to retrieve them, apply the user changes, and submit them all.

It is not that our D-Bus API is bad, it is that the use case is not exactly the same. Actually, our old CLI was closer to the D-Bus design, but we prefer the new one.
</details>

## A proposal

We have been thinking about how to solve this problem. We are not happy (yet) with the solution, but we decided to go with the following approach:

1. Read the current settings from the D-bus server. We represent that information in memory (now we use a set of simple structs, that might change tomorrow) :-) Of course, we do not need to read all the data, but let's improve that later.
2. Apply the changes that the user specified.
3. Write the data back to the server (again, let's optimize later).

These are the moving parts:

* A [settings::Item](https://github.com/imobachgs/dinstaller-rs/blob/51994550591e672e54dffac06f4a2be54d821e7e/dinstaller-lib/src/settings.rs#L70-L83) struct represents the known config elements. It contains the logic to update the [settings](https://github.com/imobachgs/dinstaller-rs/blob/51994550591e672e54dffac06f4a2be54d821e7e/dinstaller-lib/src/settings.rs#L6). In the future it might be useful for the `info` command, as it could be able to retrieve the possible values.
* The [settings::ItemsRepository](https://github.com/imobachgs/dinstaller-rs/blob/51994550591e672e54dffac06f4a2be54d821e7e/dinstaller-lib/src/settings.rs#L92-L141) holds the definitions of the known configuration items (e.g., `storage.lvm`, `users.root_password`, etc.). The process of defining them is what we need to change/simplify.
* The [settings::Store](https://github.com/imobachgs/dinstaller-rs/blob/51994550591e672e54dffac06f4a2be54d821e7e/dinstaller-lib/src/settings.rs#L28) struct is responsible from reading and writing to the D-Bus server. It relies on a set of zbus-based D-Bus clients.

## To do

- [x] Simplify the process of registering a new item.
- [ ] Reduce the duplication in the update functions. Code like [this](https://github.com/imobachgs/dinstaller-rs/blob/51994550591e672e54dffac06f4a2be54d821e7e/dinstaller-lib/src/settings.rs#L126-L131) could be reduced by just improving the `Settings` API. After all, in many cases, it is just a matter of putting some value in someplace.
- [x] ~~Consider using a hash-like structure for the `Settings`~~ (using a different approach now).
- [ ] ~~Add support for the storage settings~~ (postponed)