### PR TITLE
refactor: add a macro to derive the Attributes trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -240,9 +240,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dinstaller-derive"
+version = "0.1.0"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "dinstaller-lib"
 version = "0.1.0"
 dependencies = [
+ "dinstaller-derive",
  "serde",
  "zbus",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
   "dinstaller-lib",
-  "dinstaller-cli"
+  "dinstaller-cli",
+  "dinstaller-derive"
 ]

--- a/dinstaller-derive/Cargo.toml
+++ b/dinstaller-derive/Cargo.toml
@@ -1,11 +1,12 @@
 [package]
-name = "dinstaller-lib"
+name = "dinstaller-derive"
 version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[lib]
+proc-macro = true
 
 [dependencies]
-zbus = "3.7.0"
-serde = { version = "1.0.152", features = ["derive"] }
-dinstaller-derive = { path="../dinstaller-derive" }
+quote = "1.0.23"
+syn = "1.0.107"

--- a/dinstaller-derive/src/lib.rs
+++ b/dinstaller-derive/src/lib.rs
@@ -1,0 +1,27 @@
+use proc_macro::TokenStream;
+use quote::quote;
+use syn::{ parse_macro_input, DeriveInput, Fields };
+
+#[proc_macro_derive(DInstallerAttributes)]
+pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let fields = match &input.data {
+        syn::Data::Struct(syn::DataStruct { fields: Fields::Named(fields), ..}) => &fields.named,
+        _ => panic!("only structs are supported")
+    };
+    let field_name = fields.iter().map(|field| &field.ident);
+    let name = input.ident;
+    let expanded = quote! {
+        impl Attributes for #name {
+            fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+                match attr {
+                    #(stringify!(#field_name) => self.#field_name = value.try_into()?,)*
+                    _ => return Err("unknown attribute")
+                };
+                Ok(())
+            }
+        }
+    };
+
+    TokenStream::from(expanded)
+}

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -1,14 +1,14 @@
 use crate::users::{UsersClient, FirstUser};
-use crate::storage::StorageClient;
 use std::{str::FromStr, error::Error, default::Default};
 use crate::attributes::{Attributes, AttributeValue};
+use dinstaller_derive::DInstallerAttributes;
 
 #[derive(Debug, Default)]
 pub struct Settings {
     pub user: UserSettings,
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug, Default, DInstallerAttributes)]
 pub struct UserSettings {
     pub full_name: String,
     pub user_name: String,
@@ -16,7 +16,7 @@ pub struct UserSettings {
     pub autologin: bool,
 }
 
-#[derive(Debug)]
+#[derive(Debug, DInstallerAttributes)]
 pub struct StorageSettings {
     lvm: bool,
     encryption_password: String
@@ -31,30 +31,6 @@ impl Attributes for Settings {
                 },
                 _ => return Err("unknown attribute")
             }
-        }
-        Ok(())
-    }
-}
-
-impl Attributes for UserSettings {
-    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
-        match attr {
-            "full_name" => self.full_name = value.try_into()?,
-            "user_name" => self.user_name = value.try_into()?,
-            "password" => self.password = value.try_into()?,
-            "autologin" => self.autologin = value.try_into()?,
-            _ => return Err("unknown attribute")
-        }
-        Ok(())
-    }
-}
-
-impl Attributes for StorageSettings {
-    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
-        match attr {
-            "lvm" => self.lvm = value.try_into()?,
-            "encryption_password" => self.encryption_password = value.try_into()?,
-            _ => return Err("unknown attribute")
         }
         Ok(())
     }


### PR DESCRIPTION
It is not 100% complete, but it is good enough for a Hack Week project. The idea is to automatically generate the implementation for the `Attributes` trait. As we continue adding features (e.g., "config show"), this trait will grow, and there is no point in writing that code by hand. Additionally, it was a good introduction to proc-macros.

What is missing? Well, support for nested attributes, proper error reporting and skipping the private attributes (we have none by now, but...). Oh, and the naming sucks, but that's something that we need to fix for the whole project.