### PR TITLE
feat: add support for product selection

### DIFF
--- a/dinstaller-lib/src/proxies.rs
+++ b/dinstaller-lib/src/proxies.rs
@@ -145,7 +145,9 @@ trait Questions1 {
 #[dbus_proxy(
     interface = "org.opensuse.DInstaller.Software1",
     default_service = "org.opensuse.DInstaller.Software",
-    default_path = "/org/opensuse/DInstaller/Software1"
+    default_path = "/org/opensuse/DInstaller/Software1",
+    gen_async = false,
+    gen_blocking = true
 )]
 trait Software1 {
     /// Finish method
@@ -192,7 +194,9 @@ trait Software1 {
 #[dbus_proxy(
     interface = "org.opensuse.DInstaller.Software.Proposal1",
     default_service = "org.opensuse.DInstaller.Software",
-    default_path = "/org/opensuse/DInstaller/Software/Proposal1"
+    default_path = "/org/opensuse/DInstaller/Software/Proposal1",
+    gen_async = false,
+    gen_blocking = true
 )]
 trait SoftwareProposal1 {
     /// AddResolvables method

--- a/dinstaller-lib/src/software.rs
+++ b/dinstaller-lib/src/software.rs
@@ -10,15 +10,13 @@ pub struct Product {
 }
 
 pub struct SoftwareClient<'a> {
-    pub connection: Connection,
     software_proxy: Software1Proxy<'a>,
 }
 
 impl<'a> SoftwareClient<'a> {
     pub fn new(connection: Connection) -> zbus::Result<Self> {
         Ok(Self {
-            software_proxy: Software1Proxy::new(&connection)?,
-            connection,
+            software_proxy: Software1Proxy::new(&connection)?
         })
     }
 


### PR DESCRIPTION
It allows setting the product through the `software.product` key:

```
 ./dinstaller-cli set software.product=Tumbleweed
```

NOTE: we need to implement the `info` command to find the product IDs (`Tumbleweed`, `Leap`, `Leap Micro` and `ALP`).