### PR TITLE
ensure that there is no busy services

### DIFF
--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -38,6 +38,12 @@ fn probe() {
 }
 
 fn main() {
+    let manager = manager::ManagerClient::new(dinstaller_lib::connection().unwrap()).unwrap();
+    let services = manager.busy_services().unwrap();
+    if !services.is_empty() {
+        eprintln!("There are busy services {:?}. Cannot do command.", services);
+        return;
+    }
     let cli = Cli::parse();
     match cli.command {
         Commands::Config(subcommand) => run_config_cmd(subcommand, cli.format).unwrap(),


### PR DESCRIPTION
ensure that we run command when there is no busy services to avoid collisions. We will need in future to allow commands that display progress to continue.