### PR TITLE
Set collections and commit storage settings

### DIFF
--- a/dinstaller-cli/src/config.rs
+++ b/dinstaller-cli/src/config.rs
@@ -1,6 +1,6 @@
 use crate::printers::{print, Format};
 use clap::Subcommand;
-use dinstaller_lib::attributes::{AttributeValue, Attributes};
+use dinstaller_lib::settings::{SettingValue, Settings};
 use dinstaller_lib::Store as SettingsStore;
 use std::{collections::HashMap, error::Error, io};
 
@@ -30,7 +30,7 @@ pub fn run(subcommand: ConfigCommands, format: Option<Format>) -> Result<(), Box
     match parse_config_command(subcommand) {
         ConfigAction::Set(changes) => {
             for (key, value) in changes {
-                model.set(&key, AttributeValue(value))?;
+                model.set(&key, SettingValue(value))?;
             }
             store.store(&model)
         }
@@ -39,7 +39,7 @@ pub fn run(subcommand: ConfigCommands, format: Option<Format>) -> Result<(), Box
             Ok(())
         }
         ConfigAction::Add(key, value) => {
-            model.add(&key, AttributeValue(value))?;
+            model.add(&key, SettingValue(value))?;
             store.store(&model)
         }
     }

--- a/dinstaller-cli/src/config.rs
+++ b/dinstaller-cli/src/config.rs
@@ -1,13 +1,13 @@
 use crate::printers::{print, Format};
 use clap::Subcommand;
-use dinstaller_lib::settings::{SettingValue, Settings};
+use dinstaller_lib::settings::{SettingObject, SettingValue, Settings};
 use dinstaller_lib::Store as SettingsStore;
 use std::{collections::HashMap, error::Error, io};
 
 #[derive(Subcommand, Debug)]
 pub enum ConfigCommands {
     /// Add an element to a collection
-    Add { key: String, value: String },
+    Add { key: String, values: Vec<String> },
     /// Set one or many installation settings
     Set {
         /// key-value pairs (e.g., user.name="Jane Doe")
@@ -18,7 +18,7 @@ pub enum ConfigCommands {
 }
 
 pub enum ConfigAction {
-    Add(String, String),
+    Add(String, HashMap<String, String>),
     Set(HashMap<String, String>),
     Show,
 }
@@ -38,8 +38,8 @@ pub fn run(subcommand: ConfigCommands, format: Option<Format>) -> Result<(), Box
             print(model, io::stdout(), format)?;
             Ok(())
         }
-        ConfigAction::Add(key, value) => {
-            model.add(&key, SettingValue(value))?;
+        ConfigAction::Add(key, values) => {
+            model.add(&key, SettingObject::from(values))?;
             store.store(&model)
         }
     }
@@ -47,20 +47,21 @@ pub fn run(subcommand: ConfigCommands, format: Option<Format>) -> Result<(), Box
 
 fn parse_config_command(subcommand: ConfigCommands) -> ConfigAction {
     match subcommand {
-        ConfigCommands::Add { key, value } => ConfigAction::Add(key, value),
+        ConfigCommands::Add { key, values } => ConfigAction::Add(key, parse_keys_values(values)),
         ConfigCommands::Show => ConfigAction::Show,
-        ConfigCommands::Set { values } => {
-            let changes: HashMap<String, String> = values
-                .iter()
-                .filter_map(|s| {
-                    if let Some((key, value)) = s.split_once('=') {
-                        Some((key.to_string(), value.to_string()))
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-            ConfigAction::Set(changes)
-        }
+        ConfigCommands::Set { values } => ConfigAction::Set(parse_keys_values(values)),
     }
+}
+
+fn parse_keys_values(keys_values: Vec<String>) -> HashMap<String, String> {
+    keys_values
+        .iter()
+        .filter_map(|s| {
+            if let Some((key, value)) = s.split_once('=') {
+                Some((key.to_string(), value.to_string()))
+            } else {
+                None
+            }
+        })
+        .collect()
 }

--- a/dinstaller-derive/src/lib.rs
+++ b/dinstaller-derive/src/lib.rs
@@ -36,7 +36,7 @@ pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
     if !collection.is_empty() {
         let field_name = collection.iter().map(|field| &field.ident);
         add_fn = quote! {
-            fn add(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
+            fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
                 match attr {
                     #(stringify!(#field_name) => self.#field_name.push(value.try_into()?),)*
                     _ => return Err("unknown attribute")

--- a/dinstaller-derive/src/lib.rs
+++ b/dinstaller-derive/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput, Fields};
 
-#[proc_macro_derive(DInstallerAttributes, attributes(collection))]
+#[proc_macro_derive(Settings, attributes(collection_setting))]
 pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let fields = match &input.data {
@@ -13,14 +13,16 @@ pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
         _ => panic!("only structs are supported"),
     };
 
-    let (collection, scalar): (Vec<_>, Vec<_>) = fields
-        .iter()
-        .partition(|f| f.attrs.iter().any(|a| a.path.is_ident("collection")));
+    let (collection, scalar): (Vec<_>, Vec<_>) = fields.iter().partition(|f| {
+        f.attrs
+            .iter()
+            .any(|a| a.path.is_ident("collection_setting"))
+    });
 
     let field_name = scalar.iter().map(|field| &field.ident);
     let name = input.ident;
     let set_fn = quote! {
-        fn set(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+        fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
             match attr {
                 #(stringify!(#field_name) => self.#field_name = value.try_into()?,)*
                 _ => return Err("unknown attribute")
@@ -34,7 +36,7 @@ pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
     if !collection.is_empty() {
         let field_name = collection.iter().map(|field| &field.ident);
         add_fn = quote! {
-            fn add(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+            fn add(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
                 match attr {
                     #(stringify!(#field_name) => self.#field_name.push(value.try_into()?),)*
                     _ => return Err("unknown attribute")
@@ -45,7 +47,7 @@ pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
     }
 
     let expanded = quote! {
-        impl Attributes for #name {
+        impl Settings for #name {
             #set_fn
             #add_fn
         }

--- a/dinstaller-derive/src/lib.rs
+++ b/dinstaller-derive/src/lib.rs
@@ -2,7 +2,7 @@ use proc_macro::TokenStream;
 use quote::quote;
 use syn::{parse_macro_input, DeriveInput, Fields};
 
-#[proc_macro_derive(DInstallerAttributes)]
+#[proc_macro_derive(DInstallerAttributes, attributes(collection))]
 pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
     let fields = match &input.data {
@@ -12,17 +12,42 @@ pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
         }) => &fields.named,
         _ => panic!("only structs are supported"),
     };
-    let field_name = fields.iter().map(|field| &field.ident);
+
+    let (collection, scalar): (Vec<_>, Vec<_>) = fields
+        .iter()
+        .partition(|f| f.attrs.iter().any(|a| a.path.is_ident("collection")));
+
+    let field_name = scalar.iter().map(|field| &field.ident);
     let name = input.ident;
-    let expanded = quote! {
-        impl Attributes for #name {
-            fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+    let set_fn = quote! {
+        fn set(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+            match attr {
+                #(stringify!(#field_name) => self.#field_name = value.try_into()?,)*
+                _ => return Err("unknown attribute")
+            };
+            Ok(())
+        }
+    };
+
+    let mut add_fn = quote! {};
+
+    if !collection.is_empty() {
+        let field_name = collection.iter().map(|field| &field.ident);
+        add_fn = quote! {
+            fn add(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
                 match attr {
-                    #(stringify!(#field_name) => self.#field_name = value.try_into()?,)*
+                    #(stringify!(#field_name) => self.#field_name.push(value.try_into()?),)*
                     _ => return Err("unknown attribute")
                 };
                 Ok(())
             }
+        };
+    }
+
+    let expanded = quote! {
+        impl Attributes for #name {
+            #set_fn
+            #add_fn
         }
     };
 

--- a/dinstaller-lib/src/attributes.rs
+++ b/dinstaller-lib/src/attributes.rs
@@ -38,10 +38,10 @@ use std::convert::TryFrom;
 /// }
 ///
 /// impl Attributes for Settings {
-///   fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+///   fn set(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
 ///     if let Some((ns, id)) = attr.split_once('.') {
 ///       match ns {
-///         "user" => self.user.set_attribute(id, value)?,
+///         "user" => self.user.set(id, value)?,
 ///         _ => return Err("unknown attribute")
 ///       }
 ///     }
@@ -51,13 +51,19 @@ use std::convert::TryFrom;
 ///
 /// let user = UserSettings { name: "foo".to_string(), enabled: false };
 /// let mut settings = Settings { user };
-/// settings.set_attribute("user.name", AttributeValue("foo.bar".to_string()));
-/// settings.set_attribute("user.enabled", AttributeValue("true".to_string()));
+/// settings.set("user.name", AttributeValue("foo.bar".to_string()));
+/// settings.set("user.enabled", AttributeValue("true".to_string()));
 /// assert!(&settings.user.enabled);
 /// assert_eq!(&settings.user.name, "foo.bar");
 /// ```
 pub trait Attributes {
-    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str>;
+    fn add(&mut self, _attr: &str, _value: AttributeValue) -> Result<(), &'static str> {
+        Err("unknown collection")
+    }
+
+    fn set(&mut self, _attr: &str, _value: AttributeValue) -> Result<(), &'static str> {
+        Err("unknown attribute")
+    }
 }
 
 /// Represents a string-based value and allows converting them to other types

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -1,8 +1,8 @@
 //! Configuration settings handling
 //!
 //! This module implements the mechanisms to load and store the installation settings.
-use crate::attributes::{AttributeValue, Attributes};
-use dinstaller_derive::DInstallerAttributes;
+use crate::settings::{SettingValue, Settings};
+use dinstaller_derive::Settings;
 use serde::Serialize;
 use std::default::Default;
 
@@ -17,8 +17,8 @@ pub struct InstallSettings {
     pub storage: StorageSettings,
 }
 
-impl Attributes for InstallSettings {
-    fn add(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+impl Settings for InstallSettings {
+    fn add(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
                 "software" => self.software.add(id, value)?,
@@ -30,7 +30,7 @@ impl Attributes for InstallSettings {
         Ok(())
     }
 
-    fn set(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
                 "software" => self.software.set(id, value)?,
@@ -46,7 +46,7 @@ impl Attributes for InstallSettings {
 /// User settings
 ///
 /// Holds the user settings for the installation.
-#[derive(Debug, Default, DInstallerAttributes, Serialize)]
+#[derive(Debug, Default, Settings, Serialize)]
 pub struct UserSettings {
     /// First user's full name
     pub full_name: String,
@@ -59,21 +59,21 @@ pub struct UserSettings {
 }
 
 /// Storage settings for installation
-#[derive(Debug, Default, DInstallerAttributes, Serialize)]
+#[derive(Debug, Default, Settings, Serialize)]
 pub struct StorageSettings {
     /// Whether LVM should be enabled
     pub lvm: bool,
     /// Encryption password for the storage devices (in clear text)
     pub encryption_password: String,
     /// Devices to use in the installation
-    #[collection]
+    #[collection_setting]
     pub devices: Vec<String>,
 }
 
 pub struct Device(String);
 
 /// Software settings for installation
-#[derive(Debug, Default, DInstallerAttributes, Serialize)]
+#[derive(Debug, Default, Settings, Serialize)]
 pub struct SoftwareSettings {
     /// ID of the product to install (e.g., "ALP", "Tumbleweed", etc.)
     pub product: String,

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -75,7 +75,7 @@ pub struct StorageSettings {
 #[derive(Debug, Serialize)]
 pub struct Device {
     /// Device name (e.g., "/dev/sda")
-    name: String,
+    pub name: String,
 }
 
 impl TryFrom<SettingObject> for Device {

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -11,13 +11,13 @@ use std::default::Default;
 /// This struct represents installation settings. It serves as an entry point and it is composed of
 /// other structs which hold the settings for each area ("users", "software", etc.).
 #[derive(Debug, Default, Serialize)]
-pub struct Settings {
+pub struct InstallSettings {
     pub user: UserSettings,
     pub software: SoftwareSettings,
     pub storage: StorageSettings,
 }
 
-impl Attributes for Settings {
+impl Attributes for InstallSettings {
     fn add(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -1,6 +1,6 @@
-pub mod attributes;
 pub mod install_settings;
 pub mod manager;
+pub mod settings;
 pub mod software;
 pub mod storage;
 pub mod users;

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod attributes;
+pub mod install_settings;
 pub mod manager;
 pub mod software;
 pub mod storage;
@@ -6,7 +7,6 @@ pub mod users;
 // TODO: maybe expose only clients when we have it?
 pub mod progress;
 pub mod proxies;
-pub mod settings;
 mod store;
 pub use store::Store;
 

--- a/dinstaller-lib/src/manager.rs
+++ b/dinstaller-lib/src/manager.rs
@@ -3,16 +3,17 @@ use crate::{progress::Progress, proxies::Progress1Proxy};
 use super::proxies::Manager1Proxy;
 use zbus::blocking::Connection;
 
+/// D-Bus client for the manager service
 pub struct ManagerClient<'a> {
     manager_proxy: Manager1Proxy<'a>,
-    progress_proxy: Progress1Proxy<'a>
+    progress_proxy: Progress1Proxy<'a>,
 }
 
 impl<'a> ManagerClient<'a> {
     pub fn new(connection: Connection) -> zbus::Result<Self> {
-        Ok(Self { 
+        Ok(Self {
             manager_proxy: Manager1Proxy::new(&connection)?,
-            progress_proxy: Progress1Proxy::new(&connection)?
+            progress_proxy: Progress1Proxy::new(&connection)?,
         })
     }
 
@@ -28,3 +29,4 @@ impl<'a> ManagerClient<'a> {
         Progress::from_proxy(&self.progress_proxy)
     }
 }
+

--- a/dinstaller-lib/src/proxies.rs
+++ b/dinstaller-lib/src/proxies.rs
@@ -381,6 +381,7 @@ trait Users1 {
     ) -> zbus::Result<(
         String,
         String,
+        String,
         bool,
         std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
     )>;

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -12,6 +12,7 @@
 //! taking care of the conversions automatically. The newtype [SettingValue] takes care of such a
 //! conversion.
 //!
+use std::collections::HashMap;
 /// For plain structs, the implementation can be derived.
 ///
 /// TODO: derive for top-level structs too
@@ -57,7 +58,7 @@ use std::convert::TryFrom;
 /// assert_eq!(&settings.user.name, "foo.bar");
 /// ```
 pub trait Settings {
-    fn add(&mut self, _attr: &str, _value: SettingValue) -> Result<(), &'static str> {
+    fn add(&mut self, _attr: &str, _value: SettingObject) -> Result<(), &'static str> {
         Err("unknown collection")
     }
 
@@ -78,7 +79,23 @@ pub trait Settings {
 ///   let value: bool = value.try_into().expect("the conversion failed");
 ///   assert_eq!(value, true);
 /// ```
+#[derive(Clone)]
 pub struct SettingValue(pub String);
+
+/// Represents a string-based collection and allows converting to other types
+///
+/// It wraps a hash which uses String as key and SettingValue as value.
+pub struct SettingObject(pub HashMap<String, SettingValue>);
+
+impl From<HashMap<String, String>> for SettingObject {
+    fn from(value: HashMap<String, String>) -> SettingObject {
+        let mut hash: HashMap<String, SettingValue> = HashMap::new();
+        for (k, v) in value {
+            hash.insert(k, SettingValue(v));
+        }
+        SettingObject(hash)
+    }
+}
 
 impl TryFrom<SettingValue> for bool {
     type Error = &'static str;

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -14,14 +14,28 @@ use std::default::Default;
 pub struct Settings {
     pub user: UserSettings,
     pub software: SoftwareSettings,
+    pub storage: StorageSettings,
 }
 
 impl Attributes for Settings {
-    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+    fn add(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
-                "software" => self.software.set_attribute(id, value)?,
-                "user" => self.user.set_attribute(id, value)?,
+                "software" => self.software.add(id, value)?,
+                "user" => self.user.add(id, value)?,
+                "storage" => self.storage.add(id, value)?,
+                _ => return Err("unknown attribute"),
+            }
+        }
+        Ok(())
+    }
+
+    fn set(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+        if let Some((ns, id)) = attr.split_once('.') {
+            match ns {
+                "software" => self.software.set(id, value)?,
+                "user" => self.user.set(id, value)?,
+                "storage" => self.storage.set(id, value)?,
                 _ => return Err("unknown attribute"),
             }
         }
@@ -45,13 +59,18 @@ pub struct UserSettings {
 }
 
 /// Storage settings for installation
-#[derive(Debug, DInstallerAttributes, Serialize)]
+#[derive(Debug, Default, DInstallerAttributes, Serialize)]
 pub struct StorageSettings {
     /// Whether LVM should be enabled
     pub lvm: bool,
     /// Encryption password for the storage devices (in clear text)
     pub encryption_password: String,
+    /// Devices to use in the installation
+    #[collection]
+    pub devices: Vec<String>,
 }
+
+pub struct Device(String);
 
 /// Software settings for installation
 #[derive(Debug, Default, DInstallerAttributes, Serialize)]

--- a/dinstaller-lib/src/storage.rs
+++ b/dinstaller-lib/src/storage.rs
@@ -1,5 +1,6 @@
 use super::proxies::{CalculatorProxy, Storage1Proxy, StorageProposalProxy};
 use serde::Serialize;
+use std::collections::HashMap;
 use zbus::blocking::Connection;
 
 /// Represents a storage device
@@ -54,5 +55,25 @@ impl<'a> StorageClient<'a> {
     /// Runs the probing process
     pub fn probe(&self) -> zbus::Result<()> {
         self.storage_proxy.probe()
+    }
+
+    pub fn calculate(
+        &self,
+        candidate_devices: Vec<String>,
+        encryption_password: String,
+        lvm: bool,
+    ) -> zbus::Result<u32> {
+        let mut settings: HashMap<&str, zbus::zvariant::Value<'_>> =
+            std::collections::HashMap::new();
+        settings.insert(
+            "CandidateDevices",
+            zbus::zvariant::Value::new(candidate_devices),
+        );
+        settings.insert(
+            "EncryptionPassword",
+            zbus::zvariant::Value::new(encryption_password),
+        );
+        settings.insert("LVM", zbus::zvariant::Value::new(lvm));
+        self.calculator_proxy.calculate(settings)
     }
 }

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -1,4 +1,4 @@
-use crate::settings::{Settings, SoftwareSettings, UserSettings};
+use crate::install_settings::{InstallSettings, SoftwareSettings, UserSettings};
 use crate::software::SoftwareClient;
 use crate::users::{FirstUser, UsersClient};
 use std::{default::Default, error::Error};
@@ -20,11 +20,11 @@ impl<'a> Store<'a> {
     }
 
     /// Loads the installation settings from the D-Bus service
-    pub fn load(&self) -> Result<Settings, Box<dyn Error>> {
+    pub fn load(&self) -> Result<InstallSettings, Box<dyn Error>> {
         let first_user = self.users_client.first_user()?;
         let product = self.software_client.product()?;
 
-        let settings = Settings {
+        let settings = InstallSettings {
             storage: Default::default(),
             software: SoftwareSettings { product },
             user: UserSettings {
@@ -38,7 +38,7 @@ impl<'a> Store<'a> {
     }
 
     /// Stores the given installation settings in the D-Bus service
-    pub fn store(&self, settings: &Settings) -> Result<(), Box<dyn Error>> {
+    pub fn store(&self, settings: &InstallSettings) -> Result<(), Box<dyn Error>> {
         // fixme: improve
         let first_user = FirstUser {
             user_name: settings.user.user_name.clone(),

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -75,6 +75,7 @@ impl<'a> Store<'a> {
             settings.encryption_password.clone(),
             settings.lvm,
         )?;
+        // TODO: convert the returned value to an error
         Ok(())
     }
 }

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -25,6 +25,7 @@ impl<'a> Store<'a> {
         let product = self.software_client.product()?;
 
         let settings = Settings {
+            storage: Default::default(),
             software: SoftwareSettings { product },
             user: UserSettings {
                 user_name: first_user.user_name,

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -1,7 +1,7 @@
 //! Users configuration support
 
 use super::proxies::Users1Proxy;
-use crate::attributes::{AttributeValue, Attributes};
+use crate::settings::{SettingValue, Settings};
 use serde::Serialize;
 use zbus::blocking::Connection;
 
@@ -40,8 +40,8 @@ impl FirstUser {
     }
 }
 
-impl Attributes for FirstUser {
-    fn set(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+impl Settings for FirstUser {
+    fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
         match attr {
             "full_name" => self.full_name = value.try_into()?,
             "user_name" => self.user_name = value.try_into()?,

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -25,6 +25,7 @@ impl FirstUser {
         dbus_data: zbus::Result<(
             String,
             String,
+            String,
             bool,
             std::collections::HashMap<String, zbus::zvariant::OwnedValue>,
         )>,
@@ -33,9 +34,9 @@ impl FirstUser {
         Ok(Self {
             full_name: data.0,
             user_name: data.1,
-            autologin: data.2,
-            data: data.3,
-            password: "".to_string(),
+            password: data.2,
+            autologin: data.3,
+            data: data.4,
         })
     }
 }

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -41,7 +41,7 @@ impl FirstUser {
 }
 
 impl Attributes for FirstUser {
-    fn set_attribute(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
+    fn set(&mut self, attr: &str, value: AttributeValue) -> Result<(), &'static str> {
         match attr {
             "full_name" => self.full_name = value.try_into()?,
             "user_name" => self.user_name = value.try_into()?,


### PR DESCRIPTION
* Add elements to a collection (e.g., `dinstaller-cli config add storage.devices name=/dev/sda`).
* Rename `DInstallerAttributes` to `Settings` (and introduce some improvements).
* Save the storage settings to the D-Bus service. 

## Todo

There are a few things I would like to work on, but let's keep them for a separate PR. This one is big enough.

- Allow an alternative syntax: `dinstaller-cli config add storage.devices /dev/sda
- Read storage settings from D-Bus.