### PR TITLE
Load a specification file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -257,6 +257,7 @@ dependencies = [
 name = "dinstaller-derive"
 version = "0.1.0"
 dependencies = [
+ "proc-macro2",
  "quote",
  "syn",
 ]
@@ -719,9 +720,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ef7d57beacfaf2d8aee5937dab7b7f28de3cb8b1828479bb5de2a7106f2bae2"
+checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
 dependencies = [
  "unicode-ident",
 ]

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -41,7 +41,7 @@ fn main() {
     let manager = manager::ManagerClient::new(dinstaller_lib::connection().unwrap()).unwrap();
     let services = manager.busy_services().unwrap();
     if !services.is_empty() {
-        eprintln!("There are busy services {:?}. Cannot do command.", services);
+        eprintln!("There are busy services {services:?}. Cannot do command.");
         return;
     }
     let cli = Cli::parse();

--- a/dinstaller-derive/Cargo.toml
+++ b/dinstaller-derive/Cargo.toml
@@ -8,5 +8,6 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
+proc-macro2 = "1.0.51"
 quote = "1.0.23"
 syn = "1.0.107"

--- a/dinstaller-derive/src/lib.rs
+++ b/dinstaller-derive/src/lib.rs
@@ -1,6 +1,7 @@
 use proc_macro::TokenStream;
+use proc_macro2::TokenStream as TokenStream2;
 use quote::quote;
-use syn::{parse_macro_input, DeriveInput, Fields};
+use syn::{parse_macro_input, DeriveInput, Fields, Ident};
 
 #[proc_macro_derive(Settings, attributes(collection_setting))]
 pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
@@ -13,50 +14,23 @@ pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
         _ => panic!("only structs are supported"),
     };
 
-    let (collection, scalar): (Vec<_>, Vec<_>) = fields.iter().partition(|f| {
+    let (collection, scalar): (Vec<_>, Vec<_>) = fields.clone().into_iter().partition(|f| {
         f.attrs
             .iter()
             .any(|a| a.path.is_ident("collection_setting"))
     });
 
-    let set_field_name = scalar.iter().map(|field| &field.ident);
-    let merge_field_name = set_field_name.clone();
+    let scalar_field_names: Vec<Ident> =
+        scalar.into_iter().filter_map(|field| field.ident).collect();
 
-    let set_fn = quote! {
-        fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
-            match attr {
-                #(stringify!(#set_field_name) => self.#set_field_name = value.try_into()?,)*
-                _ => return Err("unknown attribute")
-            };
-            Ok(())
-        }
-    };
+    let set_fn = expand_set_fn(&scalar_field_names);
+    let merge_fn = expand_merge_fn(&scalar_field_names);
 
-    let merge_fn = quote! {
-        fn merge(&mut self, other: Self)
-        where
-            Self: Sized,
-        {
-            #(if let Some(value) = other.#merge_field_name {
-                self.#merge_field_name = Some(value.clone())
-              })*
-        }
-    };
-
-    let mut add_fn = quote! {};
-
-    if !collection.is_empty() {
-        let field_name = collection.iter().map(|field| &field.ident);
-        add_fn = quote! {
-            fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
-                match attr {
-                    #(stringify!(#field_name) => self.#field_name.push(value.try_into()?),)*
-                    _ => return Err("unknown attribute")
-                };
-                Ok(())
-            }
-        };
-    }
+    let collection_field_names: Vec<Ident> = collection
+        .into_iter()
+        .filter_map(|field| field.ident)
+        .collect();
+    let add_fn = expand_add_fn(&collection_field_names);
 
     let name = input.ident;
     let expanded = quote! {
@@ -67,5 +41,54 @@ pub fn dinstaller_attributes_derive(input: TokenStream) -> TokenStream {
         }
     };
 
-    TokenStream::from(expanded)
+    expanded.into()
+}
+
+fn expand_set_fn(field_name: &Vec<Ident>) -> TokenStream2 {
+    if field_name.is_empty() {
+        return quote! {};
+    }
+
+    quote! {
+        fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
+            match attr {
+                #(stringify!(#field_name) => self.#field_name = value.try_into()?,)*
+                _ => return Err("unknown attribute")
+            };
+            Ok(())
+        }
+    }
+}
+
+fn expand_merge_fn(field_name: &Vec<Ident>) -> TokenStream2 {
+    if field_name.is_empty() {
+        return quote! {};
+    }
+
+    quote! {
+        fn merge(&mut self, other: Self)
+        where
+            Self: Sized,
+        {
+            #(if let Some(value) = other.#field_name {
+                self.#field_name = Some(value.clone())
+              })*
+        }
+    }
+}
+
+fn expand_add_fn(field_name: &Vec<Ident>) -> TokenStream2 {
+    if field_name.is_empty() {
+        return quote! {};
+    }
+
+    quote! {
+        fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
+            match attr {
+                #(stringify!(#field_name) => self.#field_name.push(value.try_into()?),)*
+                _ => return Err("unknown attribute")
+            };
+            Ok(())
+        }
+    }
 }

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -68,23 +68,6 @@ pub struct UserSettings {
     pub autologin: Option<bool>,
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_merge() {
-        let mut user1 = UserSettings::default();
-        let user2 = UserSettings {
-            full_name: Some("Jane Doe".to_owned()),
-            autologin: Some(true),
-            ..Default::default()
-        };
-        user1.merge(user2);
-        dbg!(user1);
-    }
-}
-
 /// Storage settings for installation
 #[derive(Debug, Default, Settings, Serialize, Deserialize)]
 pub struct StorageSettings {
@@ -122,4 +105,21 @@ impl TryFrom<SettingObject> for Device {
 pub struct SoftwareSettings {
     /// ID of the product to install (e.g., "ALP", "Tumbleweed", etc.)
     pub product: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_merge() {
+        let mut user1 = UserSettings::default();
+        let user2 = UserSettings {
+            full_name: Some("Jane Doe".to_owned()),
+            autologin: Some(true),
+            ..Default::default()
+        };
+        user1.merge(user2);
+        assert_eq!(user1.full_name.unwrap(), "Jane Doe")
+    }
 }

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -116,11 +116,27 @@ impl TryFrom<SettingValue> for bool {
     }
 }
 
+impl TryFrom<SettingValue> for Option<bool> {
+    type Error = &'static str;
+
+    fn try_from(value: SettingValue) -> Result<Self, Self::Error> {
+        Ok(Some(value.try_into()?))
+    }
+}
+
 impl TryFrom<SettingValue> for String {
     type Error = &'static str;
 
     fn try_from(value: SettingValue) -> Result<Self, Self::Error> {
         Ok(value.0)
+    }
+}
+
+impl TryFrom<SettingValue> for Option<String> {
+    type Error = &'static str;
+
+    fn try_from(value: SettingValue) -> Result<Self, Self::Error> {
+        Ok(Some(value.try_into()?))
     }
 }
 

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -30,8 +30,8 @@ use std::convert::TryFrom;
 ///
 /// #[derive(Settings)]
 /// struct UserSettings {
-///   name: String,
-///   enabled: bool
+///   name: Option<String>,
+///   enabled: Option<bool>
 /// }
 ///
 /// struct InstallSettings {
@@ -50,12 +50,12 @@ use std::convert::TryFrom;
 ///   }
 /// }
 ///
-/// let user = UserSettings { name: "foo".to_string(), enabled: false };
+/// let user = UserSettings { name: Some(String::from("foo")), enabled: Some(false) };
 /// let mut settings = InstallSettings { user };
 /// settings.set("user.name", SettingValue("foo.bar".to_string()));
 /// settings.set("user.enabled", SettingValue("true".to_string()));
-/// assert!(&settings.user.enabled);
-/// assert_eq!(&settings.user.name, "foo.bar");
+/// assert!(&settings.user.enabled.unwrap());
+/// assert_eq!(&settings.user.name.unwrap(), "foo.bar");
 /// ```
 pub trait Settings {
     fn add(&mut self, _attr: &str, _value: SettingObject) -> Result<(), &'static str> {

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -65,6 +65,13 @@ pub trait Settings {
     fn set(&mut self, _attr: &str, _value: SettingValue) -> Result<(), &'static str> {
         Err("unknown attribute")
     }
+
+    fn merge(&mut self, _other: Self)
+    where
+        Self: Sized,
+    {
+        unimplemented!()
+    }
 }
 
 /// Represents a string-based value and allows converting them to other types

--- a/dinstaller-lib/src/storage.rs
+++ b/dinstaller-lib/src/storage.rs
@@ -63,8 +63,7 @@ impl<'a> StorageClient<'a> {
         encryption_password: String,
         lvm: bool,
     ) -> zbus::Result<u32> {
-        let mut settings: HashMap<&str, zbus::zvariant::Value<'_>> =
-            std::collections::HashMap::new();
+        let mut settings: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
         settings.insert(
             "CandidateDevices",
             zbus::zvariant::Value::new(candidate_devices),

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -55,7 +55,7 @@ impl<'a> Store<'a> {
         let first_user = FirstUser {
             user_name: settings.user_name.clone().unwrap_or_default(),
             full_name: settings.full_name.clone().unwrap_or_default(),
-            autologin: settings.autologin.clone().unwrap_or_default(),
+            autologin: settings.autologin.unwrap_or_default(),
             password: settings.password.clone().unwrap_or_default(),
             ..Default::default()
         };
@@ -65,7 +65,7 @@ impl<'a> Store<'a> {
 
     fn store_software_settings(&self, settings: &SoftwareSettings) -> Result<(), Box<dyn Error>> {
         if let Some(product) = &settings.product {
-            self.software_client.select_product(&product)?;
+            self.software_client.select_product(product)?;
         }
         Ok(())
     }
@@ -74,7 +74,7 @@ impl<'a> Store<'a> {
         self.storage_client.calculate(
             settings.devices.iter().map(|d| d.name.clone()).collect(),
             settings.encryption_password.clone().unwrap_or_default(),
-            settings.lvm.clone().unwrap_or_default(),
+            settings.lvm.unwrap_or_default(),
         )?;
         // TODO: convert the returned value to an error
         Ok(())

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -29,12 +29,14 @@ impl<'a> Store<'a> {
 
         let settings = InstallSettings {
             storage: Default::default(),
-            software: SoftwareSettings { product },
+            software: SoftwareSettings {
+                product: Some(product),
+            },
             user: UserSettings {
-                user_name: first_user.user_name,
-                autologin: first_user.autologin,
-                full_name: first_user.full_name,
-                password: first_user.password,
+                user_name: Some(first_user.user_name),
+                autologin: Some(first_user.autologin),
+                full_name: Some(first_user.full_name),
+                password: Some(first_user.password),
             },
         };
         Ok(settings)
@@ -42,22 +44,19 @@ impl<'a> Store<'a> {
 
     /// Stores the given installation settings in the D-Bus service
     pub fn store(&self, settings: &InstallSettings) -> Result<(), Box<dyn Error>> {
-        dbg!("Storing {}", &settings);
-
         self.store_software_settings(&settings.software)?;
         self.store_user_settings(&settings.user)?;
         self.store_storage_settings(&settings.storage)?;
-
         Ok(())
     }
 
     fn store_user_settings(&self, settings: &UserSettings) -> Result<(), Box<dyn Error>> {
         // fixme: improve
         let first_user = FirstUser {
-            user_name: settings.user_name.clone(),
-            full_name: settings.full_name.clone(),
-            autologin: settings.autologin,
-            password: settings.password.clone(),
+            user_name: settings.user_name.clone().unwrap_or_default(),
+            full_name: settings.full_name.clone().unwrap_or_default(),
+            autologin: settings.autologin.clone().unwrap_or_default(),
+            password: settings.password.clone().unwrap_or_default(),
             ..Default::default()
         };
         self.users_client.set_first_user(&first_user)?;
@@ -65,15 +64,17 @@ impl<'a> Store<'a> {
     }
 
     fn store_software_settings(&self, settings: &SoftwareSettings) -> Result<(), Box<dyn Error>> {
-        self.software_client.select_product(&settings.product)?;
+        if let Some(product) = &settings.product {
+            self.software_client.select_product(&product)?;
+        }
         Ok(())
     }
 
     fn store_storage_settings(&self, settings: &StorageSettings) -> Result<(), Box<dyn Error>> {
         self.storage_client.calculate(
             settings.devices.iter().map(|d| d.name.clone()).collect(),
-            settings.encryption_password.clone(),
-            settings.lvm,
+            settings.encryption_password.clone().unwrap_or_default(),
+            settings.lvm.clone().unwrap_or_default(),
         )?;
         // TODO: convert the returned value to an error
         Ok(())

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -1,6 +1,7 @@
 //! Users configuration support
 
 use super::proxies::Users1Proxy;
+use crate::install_settings::UserSettings;
 use crate::settings::{SettingValue, Settings};
 use serde::Serialize;
 use zbus::blocking::Connection;
@@ -21,7 +22,7 @@ pub struct FirstUser {
 }
 
 impl FirstUser {
-    fn from_dbus(
+    pub fn from_dbus(
         dbus_data: zbus::Result<(
             String,
             String,
@@ -38,6 +39,16 @@ impl FirstUser {
             autologin: data.3,
             data: data.4,
         })
+    }
+
+    pub fn from_user_settings(settings: &UserSettings) -> Self {
+        FirstUser {
+            user_name: settings.user_name.clone().unwrap_or_default(),
+            full_name: settings.full_name.clone().unwrap_or_default(),
+            autologin: settings.autologin.clone().unwrap_or_default(),
+            password: settings.password.clone().unwrap_or_default(),
+            ..Default::default()
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds support to load a specification file using a format like this one:

```json
{
  "user": {
    "full_name": "",
    "user_name": "",
    "autologin": false
  },
  "software": {
    "product": "ALP"
  },
  "storage": {
    "lvm": false,
    "encryption_password": "",
    "devices": [{ "name": "/dev/vda" }]
  }
}
```

Now you can do:

```
dinstaller-cli config load profile.json
```

## Merging values

Until now, we have been walking through the happy path, where the `InstallSettings` struct was always complete because it came from the D-Bus API. However, we are now considering a hand-written specification, and we expect it not to be complete.

I considered having a separate data structure for that, but finally, I decided to use the [Option enum](https://doc.rust-lang.org/std/option/enum.Option.html) and add some logic to the `Settings` derive macro to perform the merge.

## To do

Some things are still pending. However, the current status is good enough to continue working in the autoinstallation PoC.

- Read storage settings
- Use `&str` as arguments to D-Bus clients.
- Merge collections
```