### PR TITLE
Reduce D-Bus calls

### DIFF
--- a/dinstaller-derive/src/lib.rs
+++ b/dinstaller-derive/src/lib.rs
@@ -66,11 +66,11 @@ fn expand_merge_fn(field_name: &Vec<Ident>) -> TokenStream2 {
     }
 
     quote! {
-        fn merge(&mut self, other: Self)
+        fn merge(&mut self, other: &Self)
         where
             Self: Sized,
         {
-            #(if let Some(value) = other.#field_name {
+            #(if let Some(value) = &other.#field_name {
                 self.#field_name = Some(value.clone())
               })*
         }

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -9,6 +9,9 @@ use std::default::Default;
 use std::str::FromStr;
 
 /// Settings scopes
+///
+/// They are used to limit the reading/writing of settings. For instance, if the Scope::Users is
+/// given, only the data related to users (UsersStore) are read/written.
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Scope {
     /// User settings
@@ -38,46 +41,6 @@ impl FromStr for Scope {
             "storage" => Ok(Self::Storage),
             _ => Err("Unknown section"),
         }
-    }
-}
-
-impl ToString for Scope {
-    fn to_string(&self) -> String {
-        match self {
-            Scope::Users => String::from("user"),
-            Scope::Software => String::from("software"),
-            Scope::Storage => String::from("storage"),
-        }
-    }
-}
-
-pub struct Key(Scope, String);
-
-impl Key {
-    pub fn scope(&self) -> Scope {
-        self.0
-    }
-
-    pub fn path(&self) -> &str {
-        &self.1
-    }
-}
-
-impl ToString for Key {
-    fn to_string(&self) -> String {
-        format!("{}.{}", self.scope().to_string(), &self.path())
-    }
-}
-
-impl FromStr for Key {
-    type Err = &'static str;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        if let Some((scope_name, path)) = s.split_once('.') {
-            let scope = Scope::from_str(scope_name)?;
-            return Ok(Key(scope, path.to_string()));
-        }
-        Err("not a valid key")
     }
 }
 

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -46,10 +46,10 @@ impl Settings for InstallSettings {
         Ok(())
     }
 
-    fn merge(&mut self, other: Self) {
-        self.software.merge(other.software);
-        self.user.merge(other.user);
-        self.storage.merge(other.storage);
+    fn merge(&mut self, other: &Self) {
+        self.software.merge(&other.software);
+        self.user.merge(&other.user);
+        self.storage.merge(&other.storage);
     }
 }
 
@@ -119,7 +119,7 @@ mod tests {
             autologin: Some(true),
             ..Default::default()
         };
-        user1.merge(user2);
+        user1.merge(&user2);
         assert_eq!(user1.full_name.unwrap(), "Jane Doe")
     }
 }

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -6,6 +6,35 @@ use dinstaller_derive::Settings;
 use serde::{Deserialize, Serialize};
 use std::convert::TryFrom;
 use std::default::Default;
+use std::str::FromStr;
+
+#[derive(PartialEq)]
+pub enum Section {
+    Users,
+    Software,
+    Storage,
+}
+
+impl Section {
+    // TODO: we can rely on strum so we do not forget to add them
+    pub fn all() -> Vec<Section> {
+        vec![Section::Software, Section::Storage, Section::Users]
+    }
+}
+
+impl FromStr for Section {
+    type Err = &'static str;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        println!("{}", &s);
+        match s {
+            "users" => Ok(Self::Users),
+            "software" => Ok(Self::Software),
+            "storage" => Ok(Self::Storage),
+            _ => Err("Unknown section"),
+        }
+    }
+}
 
 /// Installation settings
 ///
@@ -14,20 +43,29 @@ use std::default::Default;
 #[derive(Debug, Default, Serialize, Deserialize)]
 pub struct InstallSettings {
     #[serde(default)]
-    pub user: UserSettings,
+    pub user: Option<UserSettings>,
     #[serde(default)]
-    pub software: SoftwareSettings,
+    pub software: Option<SoftwareSettings>,
     #[serde(default)]
-    pub storage: StorageSettings,
+    pub storage: Option<StorageSettings>,
 }
 
 impl Settings for InstallSettings {
     fn add(&mut self, attr: &str, value: SettingObject) -> Result<(), &'static str> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
-                "software" => self.software.add(id, value)?,
-                "user" => self.user.add(id, value)?,
-                "storage" => self.storage.add(id, value)?,
+                "software" => {
+                    let software = self.software.get_or_insert(Default::default());
+                    software.add(id, value)?
+                }
+                "user" => {
+                    let user = self.user.get_or_insert(Default::default());
+                    user.add(id, value)?
+                }
+                "storage" => {
+                    let storage = self.storage.get_or_insert(Default::default());
+                    storage.add(id, value)?
+                }
                 _ => return Err("unknown attribute"),
             }
         }
@@ -37,9 +75,18 @@ impl Settings for InstallSettings {
     fn set(&mut self, attr: &str, value: SettingValue) -> Result<(), &'static str> {
         if let Some((ns, id)) = attr.split_once('.') {
             match ns {
-                "software" => self.software.set(id, value)?,
-                "user" => self.user.set(id, value)?,
-                "storage" => self.storage.set(id, value)?,
+                "software" => {
+                    let software = self.software.get_or_insert(Default::default());
+                    software.set(id, value)?
+                }
+                "user" => {
+                    let user = self.user.get_or_insert(Default::default());
+                    user.set(id, value)?
+                }
+                "storage" => {
+                    let storage = self.storage.get_or_insert(Default::default());
+                    storage.set(id, value)?
+                }
                 _ => return Err("unknown attribute"),
             }
         }
@@ -47,9 +94,20 @@ impl Settings for InstallSettings {
     }
 
     fn merge(&mut self, other: &Self) {
-        self.software.merge(&other.software);
-        self.user.merge(&other.user);
-        self.storage.merge(&other.storage);
+        if let Some(other_software) = &other.software {
+            let software = self.software.get_or_insert(Default::default());
+            software.merge(other_software);
+        }
+
+        if let Some(other_user) = &other.user {
+            let user = self.user.get_or_insert(Default::default());
+            user.merge(other_user);
+        }
+
+        if let Some(other_storage) = &other.storage {
+            let storage = self.storage.get_or_insert(Default::default());
+            storage.merge(other_storage);
+        }
     }
 }
 

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -26,8 +26,8 @@ impl Scope {
     /// Returns known scopes
     ///
     // TODO: we can rely on strum so we do not forget to add them
-    pub fn all() -> Vec<Self> {
-        vec![Scope::Software, Scope::Storage, Scope::Users]
+    pub fn all() -> [Scope; 3] {
+        [Scope::Software, Scope::Storage, Scope::Users]
     }
 }
 

--- a/dinstaller-lib/src/settings.rs
+++ b/dinstaller-lib/src/settings.rs
@@ -66,7 +66,7 @@ pub trait Settings {
         Err("unknown attribute")
     }
 
-    fn merge(&mut self, _other: Self)
+    fn merge(&mut self, _other: &Self)
     where
         Self: Sized,
     {

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -2,7 +2,7 @@ mod software;
 mod storage;
 mod users;
 
-use crate::install_settings::{InstallSettings, Section};
+use crate::install_settings::{InstallSettings, Scope};
 use crate::store::software::SoftwareStore;
 use crate::store::storage::StorageStore;
 use crate::store::users::UsersStore;
@@ -27,22 +27,22 @@ impl<'a> Store<'a> {
     }
 
     /// Loads the installation settings from the D-Bus service
-    pub fn load(&self, only: Option<Vec<Section>>) -> Result<InstallSettings, Box<dyn Error>> {
-        let sections = match only {
-            Some(sections) => sections,
-            None => Section::all(),
+    pub fn load(&self, only: Option<Vec<Scope>>) -> Result<InstallSettings, Box<dyn Error>> {
+        let scopes = match only {
+            Some(scopes) => scopes,
+            None => Scope::all(),
         };
 
         let mut settings: InstallSettings = Default::default();
-        if sections.contains(&Section::Storage) {
+        if scopes.contains(&Scope::Storage) {
             settings.storage = Some(self.storage.load()?);
         }
 
-        if sections.contains(&Section::Software) {
+        if scopes.contains(&Scope::Software) {
             settings.software = Some(self.software.load()?);
         }
 
-        if sections.contains(&Section::Users) {
+        if scopes.contains(&Scope::Users) {
             settings.user = Some(self.users.load()?);
         }
         Ok(settings)
@@ -51,13 +51,13 @@ impl<'a> Store<'a> {
     /// Stores the given installation settings in the D-Bus service
     pub fn store(&self, settings: &InstallSettings) -> Result<(), Box<dyn Error>> {
         if let Some(software) = &settings.software {
-            self.software.store(&software)?;
+            self.software.store(software)?;
         }
         if let Some(user) = &settings.user {
-            self.users.store(&user)?;
+            self.users.store(user)?;
         }
         if let Some(storage) = &settings.storage {
-            self.storage.store(&storage)?;
+            self.storage.store(storage)?;
         }
         Ok(())
     }

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -30,7 +30,7 @@ impl<'a> Store<'a> {
     pub fn load(&self, only: Option<Vec<Scope>>) -> Result<InstallSettings, Box<dyn Error>> {
         let scopes = match only {
             Some(scopes) => scopes,
-            None => Scope::all(),
+            None => Scope::all().to_vec(),
         };
 
         let mut settings: InstallSettings = Default::default();

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -1,8 +1,9 @@
+mod software;
 mod users;
 
-use crate::install_settings::{InstallSettings, SoftwareSettings, StorageSettings};
-use crate::software::SoftwareClient;
+use crate::install_settings::{InstallSettings, StorageSettings};
 use crate::storage::StorageClient;
+use crate::store::software::SoftwareStore;
 use crate::store::users::UsersStore;
 use std::{default::Default, error::Error};
 
@@ -11,7 +12,7 @@ use std::{default::Default, error::Error};
 /// This struct uses the default connection built by [connection function](super::connection).
 pub struct Store<'a> {
     users: UsersStore<'a>,
-    software_client: SoftwareClient<'a>,
+    software: SoftwareStore<'a>,
     storage_client: StorageClient<'a>,
 }
 
@@ -19,20 +20,16 @@ impl<'a> Store<'a> {
     pub fn new() -> Result<Self, zbus::Error> {
         Ok(Self {
             users: UsersStore::new(super::connection()?)?,
-            software_client: SoftwareClient::new(super::connection()?)?,
+            software: SoftwareStore::new(super::connection()?)?,
             storage_client: StorageClient::new(super::connection()?)?,
         })
     }
 
     /// Loads the installation settings from the D-Bus service
     pub fn load(&self) -> Result<InstallSettings, Box<dyn Error>> {
-        let product = self.software_client.product()?;
-
         let settings = InstallSettings {
             storage: Default::default(),
-            software: SoftwareSettings {
-                product: Some(product),
-            },
+            software: self.software.load()?,
             user: self.users.load()?,
         };
         Ok(settings)
@@ -40,16 +37,9 @@ impl<'a> Store<'a> {
 
     /// Stores the given installation settings in the D-Bus service
     pub fn store(&self, settings: &InstallSettings) -> Result<(), Box<dyn Error>> {
-        self.store_software_settings(&settings.software)?;
+        self.software.store(&settings.software)?;
         self.users.store(&settings.user)?;
         self.store_storage_settings(&settings.storage)?;
-        Ok(())
-    }
-
-    fn store_software_settings(&self, settings: &SoftwareSettings) -> Result<(), Box<dyn Error>> {
-        if let Some(product) = &settings.product {
-            self.software_client.select_product(product)?;
-        }
         Ok(())
     }
 

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -1,14 +1,16 @@
-use crate::install_settings::{InstallSettings, SoftwareSettings, StorageSettings, UserSettings};
+mod users;
+
+use crate::install_settings::{InstallSettings, SoftwareSettings, StorageSettings};
 use crate::software::SoftwareClient;
 use crate::storage::StorageClient;
-use crate::users::{FirstUser, UsersClient};
+use crate::store::users::UsersStore;
 use std::{default::Default, error::Error};
 
 /// Loading and storing the settings in the D-Bus service
 ///
 /// This struct uses the default connection built by [connection function](super::connection).
 pub struct Store<'a> {
-    users_client: UsersClient<'a>,
+    users: UsersStore<'a>,
     software_client: SoftwareClient<'a>,
     storage_client: StorageClient<'a>,
 }
@@ -16,7 +18,7 @@ pub struct Store<'a> {
 impl<'a> Store<'a> {
     pub fn new() -> Result<Self, zbus::Error> {
         Ok(Self {
-            users_client: UsersClient::new(super::connection()?)?,
+            users: UsersStore::new(super::connection()?)?,
             software_client: SoftwareClient::new(super::connection()?)?,
             storage_client: StorageClient::new(super::connection()?)?,
         })
@@ -24,7 +26,6 @@ impl<'a> Store<'a> {
 
     /// Loads the installation settings from the D-Bus service
     pub fn load(&self) -> Result<InstallSettings, Box<dyn Error>> {
-        let first_user = self.users_client.first_user()?;
         let product = self.software_client.product()?;
 
         let settings = InstallSettings {
@@ -32,12 +33,7 @@ impl<'a> Store<'a> {
             software: SoftwareSettings {
                 product: Some(product),
             },
-            user: UserSettings {
-                user_name: Some(first_user.user_name),
-                autologin: Some(first_user.autologin),
-                full_name: Some(first_user.full_name),
-                password: Some(first_user.password),
-            },
+            user: self.users.load()?,
         };
         Ok(settings)
     }
@@ -45,21 +41,8 @@ impl<'a> Store<'a> {
     /// Stores the given installation settings in the D-Bus service
     pub fn store(&self, settings: &InstallSettings) -> Result<(), Box<dyn Error>> {
         self.store_software_settings(&settings.software)?;
-        self.store_user_settings(&settings.user)?;
+        self.users.store(&settings.user)?;
         self.store_storage_settings(&settings.storage)?;
-        Ok(())
-    }
-
-    fn store_user_settings(&self, settings: &UserSettings) -> Result<(), Box<dyn Error>> {
-        // fixme: improve
-        let first_user = FirstUser {
-            user_name: settings.user_name.clone().unwrap_or_default(),
-            full_name: settings.full_name.clone().unwrap_or_default(),
-            autologin: settings.autologin.unwrap_or_default(),
-            password: settings.password.clone().unwrap_or_default(),
-            ..Default::default()
-        };
-        self.users_client.set_first_user(&first_user)?;
         Ok(())
     }
 

--- a/dinstaller-lib/src/store/software.rs
+++ b/dinstaller-lib/src/store/software.rs
@@ -1,0 +1,32 @@
+use crate::install_settings::SoftwareSettings;
+use crate::software::SoftwareClient;
+use std::error::Error;
+use zbus::blocking::Connection;
+
+/// Loads and stores the software settings from/to the D-Bus service.
+pub struct SoftwareStore<'a> {
+    software_client: SoftwareClient<'a>,
+}
+
+impl<'a> SoftwareStore<'a> {
+    pub fn new(connection: Connection) -> Result<Self, zbus::Error> {
+        Ok(Self {
+            software_client: SoftwareClient::new(connection)?,
+        })
+    }
+
+    pub fn load(&self) -> Result<SoftwareSettings, Box<dyn Error>> {
+        let product = self.software_client.product()?;
+
+        Ok(SoftwareSettings {
+            product: Some(product),
+        })
+    }
+
+    pub fn store(&self, settings: &SoftwareSettings) -> Result<(), Box<dyn Error>> {
+        if let Some(product) = &settings.product {
+            self.software_client.select_product(product)?;
+        }
+        Ok(())
+    }
+}

--- a/dinstaller-lib/src/store/storage.rs
+++ b/dinstaller-lib/src/store/storage.rs
@@ -1,0 +1,32 @@
+use crate::install_settings::StorageSettings;
+use crate::storage::StorageClient;
+use std::default::Default;
+use std::error::Error;
+use zbus::blocking::Connection;
+
+/// Loads and stores the storage settings from/to the D-Bus service.
+pub struct StorageStore<'a> {
+    storage_client: StorageClient<'a>,
+}
+
+impl<'a> StorageStore<'a> {
+    pub fn new(connection: Connection) -> Result<Self, zbus::Error> {
+        Ok(Self {
+            storage_client: StorageClient::new(connection)?,
+        })
+    }
+
+    // TODO: read the settings from the service
+    pub fn load(&self) -> Result<StorageSettings, Box<dyn Error>> {
+        Ok(Default::default())
+    }
+
+    pub fn store(&self, settings: &StorageSettings) -> Result<(), Box<dyn Error>> {
+        self.storage_client.calculate(
+            settings.devices.iter().map(|d| d.name.clone()).collect(),
+            settings.encryption_password.clone().unwrap_or_default(),
+            settings.lvm.unwrap_or_default(),
+        )?;
+        Ok(())
+    }
+}

--- a/dinstaller-lib/src/store/users.rs
+++ b/dinstaller-lib/src/store/users.rs
@@ -1,0 +1,40 @@
+use crate::install_settings::UserSettings;
+use crate::users::{FirstUser, UsersClient};
+use std::error::Error;
+use zbus::blocking::Connection;
+
+/// Loads and stores the users settings from/to the D-Bus service.
+pub struct UsersStore<'a> {
+    users_client: UsersClient<'a>,
+}
+
+impl<'a> UsersStore<'a> {
+    pub fn new(connection: Connection) -> Result<Self, zbus::Error> {
+        Ok(Self {
+            users_client: UsersClient::new(connection)?,
+        })
+    }
+
+    pub fn load(&self) -> Result<UserSettings, Box<dyn Error>> {
+        let first_user = self.users_client.first_user()?;
+        Ok(UserSettings {
+            user_name: Some(first_user.user_name),
+            autologin: Some(first_user.autologin),
+            full_name: Some(first_user.full_name),
+            password: Some(first_user.password),
+        })
+    }
+
+    pub fn store(&self, settings: &UserSettings) -> Result<(), Box<dyn Error>> {
+        // fixme: improve
+        let first_user = FirstUser {
+            user_name: settings.user_name.clone().unwrap_or_default(),
+            full_name: settings.full_name.clone().unwrap_or_default(),
+            autologin: settings.autologin.unwrap_or_default(),
+            password: settings.password.clone().unwrap_or_default(),
+            ..Default::default()
+        };
+        self.users_client.set_first_user(&first_user)?;
+        Ok(())
+    }
+}

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -45,7 +45,7 @@ impl FirstUser {
         FirstUser {
             user_name: settings.user_name.clone().unwrap_or_default(),
             full_name: settings.full_name.clone().unwrap_or_default(),
-            autologin: settings.autologin.clone().unwrap_or_default(),
+            autologin: settings.autologin.unwrap_or_default(),
             password: settings.password.clone().unwrap_or_default(),
             ..Default::default()
         }


### PR DESCRIPTION
Fixes #28.

Reduce the number of D-Bus calls. Instead of adding complex logic to determine if we should do every single call, we are just considering the scope of each call.

For instance, the following command implies reading/writing user settings. Remember that, in our D-Bus API, you must retrieve all user attributes to send them again (including the changed one).

```
dinstaller-cli config set user.full_name="Jane Doe"
``` 

When working with profiles, only defined sections (scopes) are considered. In the following example, only the software settings are read/written.

```json
{
  "software": {
    "product": "ALP"
  }
}
```

Note: I took the chance to extract the logic for reading/storing each scope data to separate structs.