### PR TITLE
[WIP] Introduce error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -449,6 +449,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror",
  "zbus",
 ]
 

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -105,7 +105,11 @@ fn main() {
     match cli.command {
         Commands::Config(subcommand) => block_on(run_config_cmd(subcommand, cli.format)).unwrap(),
         Commands::Probe => block_on(probe(&manager)),
-        Commands::Profile(subcommand) => run_profile_cmd(subcommand).unwrap(),
+        Commands::Profile(subcommand) => {
+            if let Err(error) = run_profile_cmd(subcommand) {
+                eprintln!("{}", error);
+            }
+        }
         Commands::Install => block_on(install(&manager)),
         _ => unimplemented!(),
     }

--- a/dinstaller-cli/src/profile.rs
+++ b/dinstaller-cli/src/profile.rs
@@ -1,4 +1,5 @@
 use clap::Subcommand;
+use dinstaller_lib::error::ProfileError;
 use dinstaller_lib::profile::{download, ProfileEvaluator, ProfileValidator, ValidationResult};
 use std::{error::Error, path::Path};
 
@@ -14,7 +15,7 @@ pub enum ProfileCommands {
     Evaluate { path: String },
 }
 
-fn validate(path: String) -> Result<(), Box<dyn Error>> {
+fn validate(path: String) -> Result<(), ProfileError> {
     let validator = ProfileValidator::default_schema()?;
     let path = Path::new(&path);
     let result = validator.validate_file(path)?;
@@ -32,12 +33,12 @@ fn validate(path: String) -> Result<(), Box<dyn Error>> {
     Ok(())
 }
 
-fn evaluate(path: String) -> Result<(), Box<dyn Error>> {
+fn evaluate(path: String) -> Result<(), ProfileError> {
     let evaluator = ProfileEvaluator {};
     evaluator.evaluate(Path::new(&path))
 }
 
-pub fn run(subcommand: ProfileCommands) -> Result<(), Box<dyn Error>> {
+pub fn run(subcommand: ProfileCommands) -> Result<(), ProfileError> {
     match subcommand {
         ProfileCommands::Download { url } => download(&url),
         ProfileCommands::Validate { path } => validate(path),

--- a/dinstaller-lib/Cargo.toml
+++ b/dinstaller-lib/Cargo.toml
@@ -15,3 +15,4 @@ jsonschema = { version = "0.16.1", default-features = false }
 features = { version = "0.10.0", default-features = false }
 serde_json = "1.0.94"
 tempfile = "3.4.0"
+thiserror = "1.0.39"

--- a/dinstaller-lib/src/error.rs
+++ b/dinstaller-lib/src/error.rs
@@ -1,0 +1,6 @@
+use thiserror::Error;
+use zbus;
+
+#[derive(Error, Debug)]
+#[error("D-Bus service error: {0}")]
+pub struct ServiceError(#[from] zbus::Error);

--- a/dinstaller-lib/src/error.rs
+++ b/dinstaller-lib/src/error.rs
@@ -1,6 +1,23 @@
+use curl;
+use serde_json;
+use std::io;
 use thiserror::Error;
 use zbus;
 
 #[derive(Error, Debug)]
 #[error("D-Bus service error: {0}")]
 pub struct ServiceError(#[from] zbus::Error);
+
+#[derive(Error, Debug)]
+pub enum ProfileError {
+    #[error("Cannot read the profile '{0}'")]
+    Unreachable(#[from] curl::Error),
+    #[error("No hardware information available: '{0}'")]
+    NoHardwareInfo(io::Error),
+    #[error("Could not evaluate the profile: '{0}'")]
+    EvaluationError(io::Error),
+    #[error("Input/output error: '{0}'")]
+    InputOutputError(#[from] io::Error),
+    #[error("The profile is not a valid JSON file")]
+    FormatError(#[from] serde_json::Error),
+}

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -12,14 +12,18 @@ pub mod proxies;
 mod store;
 pub use store::Store;
 
+use crate::error::ServiceError;
 use std::path::Path;
 
-pub async fn connection() -> Result<zbus::Connection, zbus::Error> {
+pub async fn connection() -> Result<zbus::Connection, ServiceError> {
     let path = if Path::new("/run/d-installer/bus").exists() {
         "/run/d-installer/bus"
     } else {
         "/run/dbus/system_bus_socket"
     };
     let address = format!("unix:path={path}");
-    zbus::ConnectionBuilder::address(address.as_str())?.build().await
+    let conn = zbus::ConnectionBuilder::address(address.as_str())?
+        .build()
+        .await?;
+    Ok(conn)
 }

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod error;
 pub mod install_settings;
 pub mod manager;
 pub mod profile;

--- a/dinstaller-lib/src/manager.rs
+++ b/dinstaller-lib/src/manager.rs
@@ -1,3 +1,4 @@
+use crate::error::ServiceError;
 use crate::{progress::Progress, proxies::Progress1Proxy};
 
 use super::proxies::Manager1Proxy;
@@ -17,23 +18,23 @@ impl<'a> ManagerClient<'a> {
         })
     }
 
-    pub async fn busy_services(&self) -> zbus::Result<Vec<String>> {
-        self.manager_proxy.busy_services().await
+    pub async fn busy_services(&self) -> Result<Vec<String>, ServiceError> {
+        Ok(self.manager_proxy.busy_services().await?)
     }
 
-    pub async fn probe(&self) -> zbus::Result<()> {
-        self.manager_proxy.probe().await
+    pub async fn probe(&self) -> Result<(), ServiceError> {
+        Ok(self.manager_proxy.probe().await?)
     }
 
-    pub async fn install(&self) -> zbus::Result<()> {
-        self.manager_proxy.commit().await
+    pub async fn install(&self) -> Result<(), ServiceError> {
+        Ok(self.manager_proxy.commit().await?)
     }
 
-    pub async fn can_install(&self) -> zbus::Result<bool> {
-        self.manager_proxy.can_install().await
+    pub async fn can_install(&self) -> Result<bool, ServiceError> {
+        Ok(self.manager_proxy.can_install().await?)
     }
 
     pub async fn progress(&self) -> zbus::Result<Progress> {
-        Progress::from_proxy(&self.progress_proxy).await
+        Ok(Progress::from_proxy(&self.progress_proxy).await?)
     }
 }

--- a/dinstaller-lib/src/profile.rs
+++ b/dinstaller-lib/src/profile.rs
@@ -39,8 +39,9 @@ pub enum ValidationResult {
 /// ```
 /// # use dinstaller_lib::profile::{ProfileValidator, ValidationResult};
 /// # use std::path::Path;
-/// let validator = ProfileValidator::default_schema()
-///   .expect("the default validtor");
+/// let validator = ProfileValidator::new(
+///   Path::new("share/profile.schema.json")
+/// ).expect("the default validator");
 ///
 /// // you can validate a &str
 /// let wrong_profile = r#"

--- a/dinstaller-lib/src/software.rs
+++ b/dinstaller-lib/src/software.rs
@@ -1,4 +1,5 @@
 use super::proxies::Software1Proxy;
+use crate::error::ServiceError;
 use serde::Serialize;
 use zbus::Connection;
 
@@ -19,17 +20,18 @@ pub struct SoftwareClient<'a> {
 }
 
 impl<'a> SoftwareClient<'a> {
-    pub async fn new(connection: Connection) -> zbus::Result<SoftwareClient<'a>> {
+    pub async fn new(connection: Connection) -> Result<SoftwareClient<'a>, ServiceError> {
         Ok(Self {
             software_proxy: Software1Proxy::new(&connection).await?,
         })
     }
 
     /// Returns the available products
-    pub async fn products(&self) -> zbus::Result<Vec<Product>> {
+    pub async fn products(&self) -> Result<Vec<Product>, ServiceError> {
         let products: Vec<Product> = self
             .software_proxy
-            .available_base_products().await?
+            .available_base_products()
+            .await?
             .into_iter()
             .map(|(id, name, data)| {
                 let description = match data.get("description") {
@@ -47,12 +49,12 @@ impl<'a> SoftwareClient<'a> {
     }
 
     /// Returns the selected product to install
-    pub async fn product(&self) -> zbus::Result<String> {
-        self.software_proxy.selected_base_product().await
+    pub async fn product(&self) -> Result<String, ServiceError> {
+        Ok(self.software_proxy.selected_base_product().await?)
     }
 
     /// Selects the product to install
-    pub async fn select_product(&self, product_id: &str) -> zbus::Result<()> {
-        self.software_proxy.select_product(product_id).await
+    pub async fn select_product(&self, product_id: &str) -> Result<(), ServiceError> {
+        Ok(self.software_proxy.select_product(product_id).await?)
     }
 }

--- a/dinstaller-lib/src/storage.rs
+++ b/dinstaller-lib/src/storage.rs
@@ -1,4 +1,5 @@
 use super::proxies::{CalculatorProxy, Storage1Proxy, StorageProposalProxy};
+use crate::error::ServiceError;
 use serde::Serialize;
 use std::collections::HashMap;
 use zbus::Connection;
@@ -18,7 +19,7 @@ pub struct StorageClient<'a> {
 }
 
 impl<'a> StorageClient<'a> {
-    pub async fn new(connection: Connection) -> zbus::Result<StorageClient<'a>> {
+    pub async fn new(connection: Connection) -> Result<StorageClient<'a>, ServiceError> {
         Ok(Self {
             calculator_proxy: CalculatorProxy::new(&connection).await?,
             storage_proxy: Storage1Proxy::new(&connection).await?,
@@ -30,17 +31,18 @@ impl<'a> StorageClient<'a> {
     ///
     /// The proposal might not exist.
     // NOTE: should we implement some kind of memoization?
-    async fn proposal_proxy(&self) -> zbus::Result<StorageProposalProxy<'a>> {
-        StorageProposalProxy::new(&self.connection).await
+    async fn proposal_proxy(&self) -> Result<StorageProposalProxy<'a>, ServiceError> {
+        Ok(StorageProposalProxy::new(&self.connection).await?)
     }
 
     /// Returns the available devices
     ///
     /// These devices can be used for installing the system.
-    pub async fn available_devices(&self) -> zbus::Result<Vec<StorageDevice>> {
+    pub async fn available_devices(&self) -> Result<Vec<StorageDevice>, ServiceError> {
         let devices: Vec<_> = self
             .calculator_proxy
-            .available_devices().await?
+            .available_devices()
+            .await?
             .into_iter()
             .map(|(name, description, _)| StorageDevice { name, description })
             .collect();
@@ -48,13 +50,13 @@ impl<'a> StorageClient<'a> {
     }
 
     /// Returns the candidate devices for the proposal
-    pub async fn candidate_devices(&self) -> zbus::Result<Vec<String>> {
-        self.proposal_proxy().await?.candidate_devices().await
+    pub async fn candidate_devices(&self) -> Result<Vec<String>, ServiceError> {
+        Ok(self.proposal_proxy().await?.candidate_devices().await?)
     }
 
     /// Runs the probing process
-    pub async fn probe(&self) -> zbus::Result<()> {
-        self.storage_proxy.probe().await
+    pub async fn probe(&self) -> Result<(), ServiceError> {
+        Ok(self.storage_proxy.probe().await?)
     }
 
     pub async fn calculate(
@@ -62,7 +64,7 @@ impl<'a> StorageClient<'a> {
         candidate_devices: Vec<String>,
         encryption_password: String,
         lvm: bool,
-    ) -> zbus::Result<u32> {
+    ) -> Result<u32, ServiceError> {
         let mut settings: HashMap<&str, zbus::zvariant::Value<'_>> = HashMap::new();
         settings.insert(
             "CandidateDevices",
@@ -73,6 +75,6 @@ impl<'a> StorageClient<'a> {
             zbus::zvariant::Value::new(encryption_password),
         );
         settings.insert("LVM", zbus::zvariant::Value::new(lvm));
-        self.calculator_proxy.calculate(settings).await
+        Ok(self.calculator_proxy.calculate(settings).await?)
     }
 }

--- a/dinstaller-lib/src/store.rs
+++ b/dinstaller-lib/src/store.rs
@@ -2,6 +2,7 @@ mod software;
 mod storage;
 mod users;
 
+use crate::error::ServiceError;
 use crate::install_settings::{InstallSettings, Scope};
 use crate::store::software::SoftwareStore;
 use crate::store::storage::StorageStore;
@@ -19,7 +20,7 @@ pub struct Store<'a> {
 }
 
 impl<'a> Store<'a> {
-    pub async fn new(connection: Connection) -> Result<Store<'a>, zbus::Error> {
+    pub async fn new(connection: Connection) -> Result<Store<'a>, ServiceError> {
         Ok(Self {
             users: UsersStore::new(connection.clone()).await?,
             software: SoftwareStore::new(connection.clone()).await?,

--- a/dinstaller-lib/src/store/software.rs
+++ b/dinstaller-lib/src/store/software.rs
@@ -1,3 +1,4 @@
+use crate::error::ServiceError;
 use crate::install_settings::SoftwareSettings;
 use crate::software::SoftwareClient;
 use std::error::Error;
@@ -9,7 +10,7 @@ pub struct SoftwareStore<'a> {
 }
 
 impl<'a> SoftwareStore<'a> {
-    pub async fn new(connection: Connection) -> Result<SoftwareStore<'a>, zbus::Error> {
+    pub async fn new(connection: Connection) -> Result<SoftwareStore<'a>, ServiceError> {
         Ok(Self {
             software_client: SoftwareClient::new(connection).await?,
         })

--- a/dinstaller-lib/src/store/storage.rs
+++ b/dinstaller-lib/src/store/storage.rs
@@ -1,3 +1,4 @@
+use crate::error::ServiceError;
 use crate::install_settings::StorageSettings;
 use crate::storage::StorageClient;
 use std::default::Default;
@@ -10,7 +11,7 @@ pub struct StorageStore<'a> {
 }
 
 impl<'a> StorageStore<'a> {
-    pub async fn new(connection: Connection) -> Result<StorageStore<'a>, zbus::Error> {
+    pub async fn new(connection: Connection) -> Result<StorageStore<'a>, ServiceError> {
         Ok(Self {
             storage_client: StorageClient::new(connection).await?,
         })

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -1,6 +1,7 @@
 //! Users configuration support
 
 use super::proxies::Users1Proxy;
+use crate::error::ServiceError;
 use crate::install_settings::UserSettings;
 use crate::settings::{SettingValue, Settings};
 use serde::Serialize;
@@ -83,8 +84,8 @@ impl<'a> UsersClient<'a> {
     }
 
     /// Whether the root password is set or not
-    pub async fn is_root_password(&self) -> zbus::Result<bool> {
-        self.users_proxy.root_password_set().await
+    pub async fn is_root_password(&self) -> Result<bool, ServiceError> {
+        Ok(self.users_proxy.root_password_set().await?)
     }
 
     /// Returns the SSH key for the root user
@@ -93,13 +94,18 @@ impl<'a> UsersClient<'a> {
     }
 
     /// Set the configuration for the first user
-    pub async fn set_first_user(&self, first_user: &FirstUser) -> zbus::Result<(bool, Vec<String>)> {
-        self.users_proxy.set_first_user(
-            &first_user.full_name,
-            &first_user.user_name,
-            &first_user.password,
-            first_user.autologin,
-            std::collections::HashMap::new(),
-        ).await
+    pub async fn set_first_user(
+        &self,
+        first_user: &FirstUser,
+    ) -> zbus::Result<(bool, Vec<String>)> {
+        self.users_proxy
+            .set_first_user(
+                &first_user.full_name,
+                &first_user.user_name,
+                &first_user.password,
+                first_user.autologin,
+                std::collections::HashMap::new(),
+            )
+            .await
     }
 }


### PR DESCRIPTION
It is time to start introducing proper error reporting. This PR introduces two kinds of (temporary) errors:

* `ServiceError`: errors related to the D-Bus communication. It uses an opaque type to hide the `zbus::Error`. We can switch from a struct to an enum if we want to distinguish several error types.
* `ProfileError`: those errors related to the profile handling. I have adapted the `main.rs` to report these errors.

## What is missing?

Most of the code in `main.rs` needs adaptation. As a side-effect of proper error handling, we could reduce the usage of the `unwrap()` function.

## Other notes

If we wanted to make the service result clauses less verbose, we could define a type:

```rust
type ServiceResult<T> = Result<T, ServiceError>;
```

But, to be honest, I prefer to leave the code as it is now.

## Resources

* I found the [Error Handling in Rust - A Pragmatic Approach](https://www.youtube.com/watch?v=jpVzSse7oJ4) talk by Luca Palmieri quite interesting.